### PR TITLE
feat(order): 관리자 주문 목록 조회 응답 필드 개선 및 검색 로직 보강

### DIFF
--- a/src/main/java/com/kt/dto/order/OrderResponse.java
+++ b/src/main/java/com/kt/dto/order/OrderResponse.java
@@ -9,13 +9,14 @@ import com.querydsl.core.annotations.QueryProjection;
 
 public interface OrderResponse {
 	record Search(
-		Long id,
-		String receiverName,
-		String productName,
-		Long quantity,
-		Long totalPrice,
-		OrderStatus status,
-		LocalDateTime createdAt
+			Long id,
+			String receiverName,
+			String username,
+			String productName,
+			Long quantity,
+			Long totalPrice,
+			OrderStatus status,
+			LocalDateTime createdAt
 	) {
 		@QueryProjection
 		public Search {
@@ -23,35 +24,63 @@ public interface OrderResponse {
 	}
 
 	record Item(
-		Long productId,
-		String productName,
-		Long price,
-		Long quantity,
-		Long lineTotal
+			Long productId,
+			String productName,
+			Long price,
+			Long quantity,
+			Long lineTotal
 	) {
 	}
 
-	// 상세조회용
+	// user 상세조회용
 	record Detail(
-		Long id,
-		String receiverName,
-		String receiverAddress,
-		String receiverMobile,
-		List<Item> items,
-		Long totalPrice,
-		OrderStatus status,
-		LocalDateTime createdAt
+			Long id,
+			String receiverName,
+			String receiverAddress,
+			String receiverMobile,
+			List<Item> items,
+			Long totalPrice,
+			OrderStatus status,
+			LocalDateTime createdAt
 	) {
 	}
 
-	// 목록용
+	// user 목록용
 	record Summary(
-		Long orderId,
-		Long totalPrice,
-		LocalDateTime createdAt,
-		OrderStatus status,
-		String firstProductName,
-		int productCount
+			Long orderId,
+			Long totalPrice,
+			LocalDateTime createdAt,
+			OrderStatus status,
+			String firstProductName,
+			int productCount
+	) {
+	}
+
+	// admin 상세 조회용
+	record AdminDetail(
+			Long id,
+			String receiverName,
+			String receiverAddress,
+			String receiverMobile,
+			List<Item> items,
+			Long totalPrice,
+			OrderStatus status,
+			LocalDateTime createdAt,
+			Long userId,
+			String username
+	) {
+	}
+
+	// admin 목록용
+	record AdminSummary(
+			Long orderId,
+			Long totalPrice,
+			LocalDateTime createdAt,
+			OrderStatus status,
+			String firstProductName,
+			int productCount,
+			Long userId,
+			String username
 	) {
 	}
 }

--- a/src/main/java/com/kt/dto/order/OrderSearchCondition.java
+++ b/src/main/java/com/kt/dto/order/OrderSearchCondition.java
@@ -1,0 +1,12 @@
+package com.kt.dto.order;
+
+import com.kt.domain.order.OrderStatus;
+
+/**
+ * username, status 검색 조건을 하나의 객체로 묶어서 전달하는 역할을 합니다.
+ */
+public record OrderSearchCondition(
+		String username,
+		OrderStatus status
+) {
+}

--- a/src/main/java/com/kt/repository/order/OrderRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/order/OrderRepositoryCustom.java
@@ -3,8 +3,12 @@ package com.kt.repository.order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.kt.domain.order.Order;
 import com.kt.dto.order.OrderResponse;
+import com.kt.dto.order.OrderSearchCondition;
 
 public interface OrderRepositoryCustom {
 	Page<OrderResponse.Search> search(String keyword, Pageable pageable);
+
+	Page<Order> findByConditions(OrderSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/kt/repository/order/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/order/OrderRepositoryCustomImpl.java
@@ -1,18 +1,26 @@
 package com.kt.repository.order;
 
+import java.util.List;
+
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import com.kt.domain.order.Order;
+import com.kt.domain.order.OrderStatus;
 import com.kt.domain.order.QOrder;
 import com.kt.domain.orderproduct.QOrderProduct;
 import com.kt.domain.product.QProduct;
+import com.kt.domain.user.QUser;
 import com.kt.dto.order.OrderResponse;
+import com.kt.dto.order.OrderSearchCondition;
 import com.kt.dto.order.QOrderResponse_Search;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -25,11 +33,12 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 	private final QOrder order = QOrder.order;
 	private final QOrderProduct orderProduct = QOrderProduct.orderProduct;
 	private final QProduct product = QProduct.product;
+	private final QUser user = QUser.user;
 
 	@Override
 	public Page<OrderResponse.Search> search(
-		String keyword,
-		Pageable pageable
+			String keyword,
+			Pageable pageable
 	) {
 		// 페이징을 구현할때
 		// offset, limit
@@ -44,37 +53,58 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 		// booleanBuilder안에다가 booleanExpression을 추가해주는 방식으로
 
 		var content = jpaQueryFactory
-			// order자리에 QOrderResponse_Search
-			// totalPrice는 product의 price * orderProduct.quantity
-			.select(new QOrderResponse_Search(
-				order.id,
-				order.receiver.name,
-				product.name,
-				orderProduct.quantity,
-				product.price.multiply(orderProduct.quantity),
-				order.status,
-				order.createdAt
-			))
-			.from(order)
-			.join(orderProduct).on(orderProduct.order.id.eq(order.id))
-			.join(product).on(orderProduct.product.id.eq(product.id))
-			.where(booleanBuilder)
-			.orderBy(order.id.desc())
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+				// order자리에 QOrderResponse_Search
+				// totalPrice는 product의 price * orderProduct.quantity
+				.select(new QOrderResponse_Search(
+						order.id,
+						order.receiver.name,
+						user.name,
+						product.name,
+						orderProduct.quantity,
+						product.price.multiply(orderProduct.quantity),
+						order.status,
+						order.createdAt
+				))
+				.from(order)
+				.join(order.user, user)
+				.join(orderProduct).on(orderProduct.order.id.eq(order.id))
+				.join(product).on(orderProduct.product.id.eq(product.id))
+				.where(booleanBuilder)
+				.orderBy(order.id.desc())
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.fetch();
 		// 최초에 페이지 접근했을때 -> 전체검색이 되야할까 아니면 특정키워드검색이 자동으로 되야하나
 		// name like '%null%' (동작 해야하나?) - 동작안해야
 		// keyword = null
 
 		var total = (long)jpaQueryFactory.select(order.id)
-			.from(order)
-			.join(orderProduct).on(orderProduct.order.id.eq(order.id))
-			.join(product).on(orderProduct.product.id.eq(product.id))
-			.where(booleanBuilder)
-			.fetch().size();
+				.from(order)
+				.join(orderProduct).on(orderProduct.order.id.eq(order.id))
+				.join(product).on(orderProduct.product.id.eq(product.id))
+				.where(booleanBuilder)
+				.fetch().size();
 
 		return new PageImpl<>(content, pageable, total);
+	}
+
+	@Override
+	public Page<Order> findByConditions(OrderSearchCondition condition, Pageable pageable) {
+		List<Order> content = jpaQueryFactory
+				.selectFrom(order)
+				.join(order.user, user).fetchJoin()
+				.where(eqUsername(condition.username()), eqStatus(condition.status()))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(order.id.desc())
+				.fetch();
+
+		JPAQuery<Long> countQuery = jpaQueryFactory
+				.select(order.count())
+				.from(order)
+				.where(eqUsername(condition.username()), eqStatus(condition.status()));
+		
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 	}
 
 	// 시작하는 '%keyword'
@@ -91,5 +121,13 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 		// 	return null;
 		// }
 		return Strings.isNotBlank(keyword) ? product.name.containsIgnoreCase(keyword) : null;
+	}
+
+	private BooleanExpression eqUsername(String username) {
+		return Strings.isNotBlank(username) ? user.name.eq(username) : null;
+	}
+
+	private BooleanExpression eqStatus(OrderStatus status) {
+		return status != null ? order.status.eq(status) : null;
 	}
 }


### PR DESCRIPTION
## 관리자 주문 목록 조회 기능 개선 (KAN-26)

### 요약
관리자 페이지의 주문 목록 조회 기능을 확장 및 개선했습니다.
	•	API 응답에 구매자(username) 와 받는 사람(receiverName) 정보를 모두 포함하도록 개선했습니다.
	•	관리자가 주문을 구매자 이름(username), 주문 상태(status) 기준으로 필터링할 수 있도록 검색 로직을 보강했습니다.

---

### 작업 내용

1) 주문 목록 조회 응답(DTO) 개선
	•	OrderResponse.Search DTO에 username 필드 추가
	•	기존 필드명(buyerName)을 username으로 통일하여 전체 DTO 간 naming 일관성 강화
	•	응답에 receiverName + username 두 정보가 모두 포함되도록 구성

2) 주문 검색 로직(QueryDSL) 보강
	•	search 메서드
	•	User 엔티티 조인 추가
	•	user.name 값을 OrderResponse.Search.username 필드에 매핑하도록 select 절 수정
	•	findByConditions 쿼리 로직 완성
	•	eqUsername: 구매자 이름(username) 기반 검색 기능 구현
	•	eqStatus: 주문 상태(OrderStatus) 기반 검색 조건 추가
---

### 기타 사항
	•	본 PR은 KAN-26 작업을 포함합니다.
	•	관리자 화면에 필요한 필드를 확장한 작업이며, 사용자 조회 API에는 영향이 없습니다.


---
### 커밋 내용

- AdminOrderController의 GET /admin/orders 응답에 구매자(User) 이름 포함
- OrderResponse.Search DTO 필드명 변경 및 확장
  - 기존 `buyerName` 필드명을 `username`으로 변경하여 DTO 간 일관성 유지
  - `receiverName`(받는 사람 이름)과 `username`(구매자 이름) 모두 응답에 포함
- OrderRepositoryCustomImpl.search 메서드 수정
  - `User` 엔티티와 조인 로직 추가
  - `user.name`을 `OrderResponse.Search`의 `username` 필드에 매핑하도록 select 절 수정
- OrderRepositoryCustomImpl.findByConditions 및 헬퍼 메소드 구현
  - `eqUsername`: `User.name` 기준 주문 검색 조건 생성 기능 구현
  - `eqStatus`: `OrderStatus` 기준 주문 검색 조건 생성 기능 구현

- 관련 지라 task
  - KAN-26 [주문] 관리자 주문 목록/상세 조회 API 구현