### PR TITLE
feat: 사용자 주문 수정 API 구현

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 	FAIL_LOGIN(HttpStatus.BAD_REQUEST, "아이디 혹은 비밀번호가 일치하지 않습니다."),
 	DOES_NOT_MATCH_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 일치하지 않습니다."),
 	CAN_NOT_ALLOWED_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
+    CANNOT_UPDATE_ORDER(HttpStatus.BAD_REQUEST, "주문을 수정할 수 없는 상태입니다."),
 	CANNOT_CANCEL_ORDER(HttpStatus.BAD_REQUEST, "주문을 취소할 수 없는 상태입니다."),
 	NO_AUTHORITY_TO_CANCEL_ORDER(HttpStatus.FORBIDDEN, "주문을 취소할 권한이 없습니다."),
 	NOT_ENOUGH_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
@@ -24,5 +25,4 @@ public enum ErrorCode {
 
 	private final HttpStatus status;
 	private final String message;
-
 }

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -56,13 +56,13 @@ public class OrderController extends SwaggerAssistance {
 
 	@Operation(
 		summary = "사용자 주문 상세 조회",
-		description = "로그인한 사용자가 자신의 주문 단건 상세를 조회합니다. 소유권 검증이 적용됩니다."
+		description = "로그인한 사용자가 자신의 주문 단건 상세를 조회합니다."
 	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "조회 성공",
 			content = @Content(schema = @Schema(implementation = com.kt.dto.order.OrderResponse.Detail.class))),
-		@ApiResponse(responseCode = "404", description = "주문 미존재 또는 소유권 불일치"),
-		@ApiResponse(responseCode = "401", description = "인증 실패")
+		@ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "주문 미존재 또는 소유권 불일치"),
 	})
 	@GetMapping("/{orderId}")
 	public ApiResult<OrderResponse.Detail> getById(
@@ -96,6 +96,26 @@ public class OrderController extends SwaggerAssistance {
 		return ApiResult.ok(page);
 	}
 
+    @Operation(
+            summary = "주문 수정",
+            description = "수령인 정보를 수정합니다. 주문 상태가 수정 가능해야 합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "현재 주문 상태에서는 수정할 수 없음")
+    })
+    @PutMapping("/{orderId}")
+    public ApiResult<Void> updateOrder(
+        @AuthenticationPrincipal DefaultCurrentUser currentUser,
+        @PathVariable Long orderId,
+        @RequestBody @Valid OrderRequest.Update request
+    ) {
+        userOrderService.updateOrder(currentUser.getId(), orderId, request);
+        return ApiResult.ok();
+    }
+
 	@Operation(
 		summary = "주문 취소",
 		description = "특정 주문을 취소합니다. 관리자 또는 주문자 본인만 취소 가능합니다."
@@ -109,7 +129,6 @@ public class OrderController extends SwaggerAssistance {
 	@PostMapping("/{orderId}/cancel")
 	public ApiResult<Void> cancelOrder(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
-		@Parameter(description = "취소할 주문 ID", example = "1")
 		@PathVariable Long orderId
 	) {
 		orderService.cancelOrder(orderId, currentUser);

--- a/src/main/java/com/kt/domain/order/Order.java
+++ b/src/main/java/com/kt/domain/order/Order.java
@@ -62,6 +62,14 @@ public class Order extends BaseEntity {
 		this.orderProducts.add(orderProduct);
 	}
 
+    public void changeReceiver(String name, String address, String mobile) {
+        this.receiver = new Receiver(name, address, mobile);
+    }
+
+    public boolean canUpdate() {
+        return this.status == OrderStatus.PENDING || this.status == OrderStatus.COMPLETED;
+    }
+
 	public void cancel() {
 		Preconditions.validate(this.status == OrderStatus.PENDING, ErrorCode.CANNOT_CANCEL_ORDER);
 		this.status = OrderStatus.CANCELLED;

--- a/src/main/java/com/kt/repository/order/OrderRepository.java
+++ b/src/main/java/com/kt/repository/order/OrderRepository.java
@@ -23,6 +23,11 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
 	@EntityGraph(attributePaths = {"orderProducts", "orderProducts.product", "user"})
 	Optional<Order> findByIdAndUserId(Long id, Long userId);
 
+    default Order findByIdAndUserIdOrThrow(Long id, Long userId, ErrorCode errorCode) {
+        return findByIdAndUserId(id, userId)
+            .orElseThrow(() -> new CustomException(errorCode));
+    }
+
 	default Order findByOrderIdOrThrow(Long id, ErrorCode errorCode) {
 		return findById(id)
 			.orElseThrow(() -> new CustomException(errorCode));

--- a/src/main/java/com/kt/service/UserOrderService.java
+++ b/src/main/java/com/kt/service/UserOrderService.java
@@ -1,11 +1,14 @@
 package com.kt.service;
 
+import com.kt.common.support.Preconditions;
 import com.kt.domain.order.Order;
+import com.kt.dto.order.OrderRequest;
 import com.kt.dto.order.OrderResponse;
 import com.kt.repository.order.OrderRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import com.kt.common.exception.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,8 +23,7 @@ public class UserOrderService {
 	// 주문 상세 조회
 	@Transactional(readOnly = true)
 	public OrderResponse.Detail getByIdForUser(Long userId, Long orderId) {
-		var order = orderRepository.findByIdAndUserId(orderId, userId)
-			.orElseThrow();
+		var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
 		return mapToDetail(order);
 	}
 
@@ -31,6 +33,18 @@ public class UserOrderService {
 		var page = orderRepository.findAllByUserId(userId, pageable);
 		return page.map(this::mapToSummary);
 	}
+
+    @Transactional
+    public void updateOrder(Long userId, Long orderId, OrderRequest.Update request) {
+        var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
+
+        Preconditions.validate(order.canUpdate(), ErrorCode.CANNOT_UPDATE_ORDER);
+        order.changeReceiver(
+                request.receiverName(),
+                request.receiverAddress(),
+                request.receiverMobile()
+        );
+    }
 
 	private OrderResponse.Detail mapToDetail(Order order) {
 		var items = order.getOrderProducts().stream().map(op -> {


### PR DESCRIPTION
**📌 사용자가 자신의 주문 정보를 수정할 수 있도록 주문 수정 API 구현**

**🛠️ Changes**
**1. UserOrderService.updateOrder 구현**
- findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.ORDER_NOT_FOUND) 사용해 주문 검증
- 주문 상태 업데이트 가능 여부 order.canUpdate() 체크 (pending 혹은 결제완료 상태만 수정 가능, 배송시작하면 수정 불가)
- order.changeReceiver() 호출하여 이름/전화번호/주소 변경

**2. OrderController 수정 API 추가**
- PUT /orders/{orderId}
- Swagger 문서화 적용
- 요청 DTO: OrderRequest.Update

**3. 예외 처리 개선**
- IllegalArgumentException → CustomException + ErrorCode 적용
- 주문 없는 경우 → NOT_FOUND_ORDER
- 수정 불가 상태 → CANNOT_UPDATE_ORDER

**4. OrderRepository 기능 추가**
- findByIdAndUserIdOrThrow() 메서드 추가(EntityGraph 포함)
- 일관된 예외 처리 방식 유지