### PR TITLE
feat(admin-order): KAN-62 관리자 주문 상세 조회 구현 및 검색 기능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ out/
 .DS_Store
 
 # Local configurations
-/src/main/resources/application-local.yml
+src/main/resources/application-loacal.yml
+resources/application-loacal.yml
 application-local.yml

--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import com.kt.domain.order.OrderStatus;
 
@@ -53,5 +55,23 @@ public class AdminOrderController {
 		Pageable pageable
 	) {
 		return ApiResult.ok(orderService.getAdminOrders(condition, pageable));
+	}
+
+	@Operation(
+		summary = "관리자 주문 상세 조회",
+		description = "관리자가 주문 ID로 특정 주문의 상세 정보를 조회합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공",
+			content = @Content(schema = @Schema(implementation = com.kt.dto.order.OrderResponse.AdminDetail.class))),
+		@ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음"),
+	})
+	@GetMapping("/{orderId}")
+	@SecurityRequirement(name = "Bearer Authentication")
+	public ApiResult<OrderResponse.AdminDetail> getDetail(
+		@Parameter(description = "조회할 주문 ID", required = true)
+		@PathVariable Long orderId
+	) {
+		return ApiResult.ok(orderService.getAdminOrderDetail(orderId));
 	}
 }

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,7 @@ public class OrderController extends SwaggerAssistance {
 
 	// 주문 생성
 	@PostMapping
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<Void> create(
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@RequestBody @Valid OrderRequest.Create request) {
@@ -65,6 +67,7 @@ public class OrderController extends SwaggerAssistance {
         @ApiResponse(responseCode = "404", description = "주문 미존재 또는 소유권 불일치"),
 	})
 	@GetMapping("/{orderId}")
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<OrderResponse.Detail> getById(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@PathVariable Long orderId
@@ -82,6 +85,7 @@ public class OrderController extends SwaggerAssistance {
 		@ApiResponse(responseCode = "401", description = "인증 실패")
 	})
 	@GetMapping
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<Page<OrderResponse.Summary>> list(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@Parameter(description = "페이징 정보(page는 1부터 시작, size는 페이지 크기)", required = true)
@@ -127,6 +131,7 @@ public class OrderController extends SwaggerAssistance {
 		@ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음")
 	})
 	@PostMapping("/{orderId}/cancel")
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<Void> cancelOrder(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
         @Parameter(description = "취소할 주문 ID", example = "1")

--- a/src/main/java/com/kt/controller/payment/PaymentController.java
+++ b/src/main/java/com/kt/controller/payment/PaymentController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,6 +39,7 @@ public class PaymentController {
 		@ApiResponse(responseCode = "500", description = "서버 에러 - 백엔드에 바로 문의 바랍니다.")
 	})
 	@PostMapping("/{orderId}/pay")
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<Void> pay(
 		@Parameter(description = "결제할 주문 ID", example = "1")
 		@PathVariable Long orderId,

--- a/src/main/java/com/kt/controller/user/AdminUserController.java
+++ b/src/main/java/com/kt/controller/user/AdminUserController.java
@@ -22,6 +22,7 @@ import com.kt.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +46,7 @@ public class AdminUserController extends SwaggerAssistance {
 	)
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<Page<UserResponse.Search>> search(
 		@AuthenticationPrincipal CurrentUser currentUser,
 		@RequestParam(required = false) String keyword,
@@ -67,6 +69,7 @@ public class AdminUserController extends SwaggerAssistance {
 
 	@GetMapping("/{id}")
 	@ResponseStatus(HttpStatus.OK)
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<UserResponse.Detail> detail(@PathVariable Long id) {
 		var user = userService.detail(id);
 
@@ -80,6 +83,7 @@ public class AdminUserController extends SwaggerAssistance {
 	// 유저 정보 수정
 	@PutMapping("/{id}")
 	@ResponseStatus(HttpStatus.OK)
+	@SecurityRequirement(name = "Bearer Authentication")
 	public ApiResult<Void> update(@PathVariable Long id, @RequestBody @Valid UserUpdateRequest request) {
 		userService.update(id, request.name(), request.email(), request.mobile());
 

--- a/src/main/java/com/kt/dto/order/OrderSearchCondition.java
+++ b/src/main/java/com/kt/dto/order/OrderSearchCondition.java
@@ -7,6 +7,7 @@ import com.kt.domain.order.OrderStatus;
  */
 public record OrderSearchCondition(
 		String username,
+		String receiverName,
 		OrderStatus status
 ) {
 }

--- a/src/main/java/com/kt/repository/order/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/order/OrderRepositoryCustomImpl.java
@@ -93,7 +93,11 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 		List<Order> content = jpaQueryFactory
 				.selectFrom(order)
 				.join(order.user, user).fetchJoin()
-				.where(eqUsername(condition.username()), eqStatus(condition.status()))
+				.where(
+						eqUsername(condition.username()),
+						eqReceiverName(condition.receiverName()),
+						eqStatus(condition.status())
+				)
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.orderBy(order.id.desc())
@@ -102,7 +106,11 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 		JPAQuery<Long> countQuery = jpaQueryFactory
 				.select(order.count())
 				.from(order)
-				.where(eqUsername(condition.username()), eqStatus(condition.status()));
+				.where(
+						eqUsername(condition.username()),
+						eqReceiverName(condition.receiverName()),
+						eqStatus(condition.status())
+				);
 		
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 	}
@@ -125,6 +133,10 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 
 	private BooleanExpression eqUsername(String username) {
 		return Strings.isNotBlank(username) ? user.name.eq(username) : null;
+	}
+
+	private BooleanExpression eqReceiverName(String receiverName) {
+		return Strings.isNotBlank(receiverName) ? order.receiver.name.eq(receiverName) : null;
 	}
 
 	private BooleanExpression eqStatus(OrderStatus status) {

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -24,6 +24,8 @@ import com.kt.security.CurrentUser;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -115,5 +117,33 @@ public class OrderService {
 				order.getUser().getName()
 			);
 		});
+	}
+
+	@Transactional(readOnly = true)
+	public OrderResponse.AdminDetail getAdminOrderDetail(Long orderId) {
+		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+
+		List<OrderResponse.Item> items = order.getOrderProducts().stream()
+			.map(op -> new OrderResponse.Item(
+				op.getProduct().getId(),
+				op.getProduct().getName(),
+				op.getProduct().getPrice(),
+				op.getQuantity(),
+				op.getProduct().getPrice() * op.getQuantity()
+			))
+			.toList();
+
+		return new OrderResponse.AdminDetail(
+			order.getId(),
+			order.getReceiver().getName(),
+			order.getReceiver().getAddress(),
+			order.getReceiver().getMobile(),
+			items,
+			order.getTotalPrice(),
+			order.getStatus(),
+			order.getCreatedAt(),
+			order.getUser().getId(),
+			order.getUser().getName()
+		);
 	}
 }


### PR DESCRIPTION
관리자 주문 상세 조회 기능을 구현하고, 주문 목록 검색 기능을 강화했습니다.
또한 인증이 필요한 API 엔드포인트에 @SecurityRequirement(name = "Bearer Authentication") 를 추가했습니다.

### 주요 변경 사항

- **관리자 주문 상세 조회 기능 추가**
  - `AdminOrderController`에 `GET /admin/orders/{orderId}` 엔드포인트를 추가하여 관리자가 특정 주문의 상세 정보를 조회할 수 있도록 구현했습니다.
  - `OrderService`에 `getAdminOrderDetail` 메소드를 추가해 구매자 및 수령인 정보를 포함한 `AdminDetail` DTO를 반환하도록 작성했습니다.

- **관리자 주문 목록 검색 기능 강화**
  - `OrderSearchCondition` DTO에 `receiverName` 필드를 추가하여 수령인 이름으로 검색할 수 있습니다.
  - `OrderRepositoryCustomImpl`의 `findByConditions` 쿼리에 `receiverName` 조건을 동적으로 포함하도록 개선했습니다.
  - `username`, `receiverName`, `status` 모두 선택적이며, 아무 조건도 없으면 전체 주문 목록을 반환합니다.

- **API 문서화 개선 (Swagger)**
  - `AdminOrderController`, `OrderController`, `PaymentController`, `AdminUserController` 등 인증이 필요한 모든 주요 엔드포인트에 `@SecurityRequirement` 추가했습니다.
  - Swagger UI에서 JWT 인증 필요 여부를 명확하게 확인할 수 있습니다.

- **기타**
  - 로컬 환경 설정 파일(`application-local.yml`)을 `.gitignore`에 추가했습니다.