### PR TITLE
feat(admin-order) KAN-27 관리자 주문 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -5,12 +5,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.response.ApiResult;
+import com.kt.common.support.SwaggerAssistance;
 import com.kt.dto.order.OrderResponse;
 import com.kt.dto.order.OrderSearchCondition;
+import com.kt.dto.order.OrderStatusUpdateRequest;
 import com.kt.service.OrderService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/admin/orders")
 @RequiredArgsConstructor
-public class AdminOrderController {
+public class AdminOrderController extends SwaggerAssistance {
 	private final OrderService orderService;
 
 	@Operation(
@@ -73,5 +77,24 @@ public class AdminOrderController {
 		@PathVariable Long orderId
 	) {
 		return ApiResult.ok(orderService.getAdminOrderDetail(orderId));
+	}
+
+	@Operation(
+		summary = "관리자 주문 상태 변경",
+		description = "관리자가 주문 ID로 특정 주문의 상태를 변경합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+		@ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음"),
+	})
+	@PostMapping("/{orderId}/change-status")
+	@SecurityRequirement(name = "Bearer Authentication")
+	public ApiResult<Void> changeStatus(
+		@Parameter(description = "상태를 변경할 주문 ID", required = true)
+		@PathVariable Long orderId,
+		@RequestBody OrderStatusUpdateRequest request
+	) {
+		orderService.changeOrderStatus(orderId, request);
+		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/domain/order/Order.java
+++ b/src/main/java/com/kt/domain/order/Order.java
@@ -85,6 +85,10 @@ public class Order extends BaseEntity {
 		this.status = OrderStatus.COMPLETED;
 	}
 
+	public void changeStatus(OrderStatus orderStatus){
+		this.status = orderStatus;
+	}
+
 	//하나의 오더는 여러개의 상품을 가질수있음
 	// 1:N
 	//하나의 상품은 여러개의 오더를 가질수있음

--- a/src/main/java/com/kt/domain/order/OrderStatus.java
+++ b/src/main/java/com/kt/domain/order/OrderStatus.java
@@ -9,7 +9,8 @@ public enum OrderStatus {
 	PENDING("결제대기"),
 	COMPLETED("결제완료"),
 	CANCELLED("주문취소"),
-	SHIPPED("배송중"),
+	PREPARING("배송준비중"),
+	SHIPPING("배송중"),
 	DELIVERED("배송완료"),
 	CONFIRMED("구매확정");
 

--- a/src/main/java/com/kt/dto/order/OrderStatusUpdateRequest.java
+++ b/src/main/java/com/kt/dto/order/OrderStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.kt.dto.order;
+
+import com.kt.domain.order.OrderStatus;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OrderStatusUpdateRequest(
+		@NotNull
+		OrderStatus status
+) {
+}

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -16,6 +16,7 @@ import com.kt.domain.orderproduct.OrderProduct;
 import com.kt.domain.user.Role;
 import com.kt.dto.order.OrderResponse;
 import com.kt.dto.order.OrderSearchCondition;
+import com.kt.dto.order.OrderStatusUpdateRequest;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
@@ -107,14 +108,14 @@ public class OrderService {
 			}
 
 			return new OrderResponse.AdminSummary(
-				order.getId(),
-				order.getTotalPrice(),
-				order.getCreatedAt(),
-				order.getStatus(),
-				firstProductName,
-				productCount,
-				order.getUser().getId(),
-				order.getUser().getName()
+					order.getId(),
+					order.getTotalPrice(),
+					order.getCreatedAt(),
+					order.getStatus(),
+					firstProductName,
+					productCount,
+					order.getUser().getId(),
+					order.getUser().getName()
 			);
 		});
 	}
@@ -124,26 +125,31 @@ public class OrderService {
 		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
 
 		List<OrderResponse.Item> items = order.getOrderProducts().stream()
-			.map(op -> new OrderResponse.Item(
-				op.getProduct().getId(),
-				op.getProduct().getName(),
-				op.getProduct().getPrice(),
-				op.getQuantity(),
-				op.getProduct().getPrice() * op.getQuantity()
-			))
-			.toList();
+				.map(op -> new OrderResponse.Item(
+						op.getProduct().getId(),
+						op.getProduct().getName(),
+						op.getProduct().getPrice(),
+						op.getQuantity(),
+						op.getProduct().getPrice() * op.getQuantity()
+				))
+				.toList();
 
 		return new OrderResponse.AdminDetail(
-			order.getId(),
-			order.getReceiver().getName(),
-			order.getReceiver().getAddress(),
-			order.getReceiver().getMobile(),
-			items,
-			order.getTotalPrice(),
-			order.getStatus(),
-			order.getCreatedAt(),
-			order.getUser().getId(),
-			order.getUser().getName()
+				order.getId(),
+				order.getReceiver().getName(),
+				order.getReceiver().getAddress(),
+				order.getReceiver().getMobile(),
+				items,
+				order.getTotalPrice(),
+				order.getStatus(),
+				order.getCreatedAt(),
+				order.getUser().getId(),
+				order.getUser().getName()
 		);
+	}
+
+	public void changeOrderStatus(Long orderId, OrderStatusUpdateRequest request) {
+		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		order.changeStatus(request.status());
 	}
 }


### PR DESCRIPTION
### 작업사항
- 관리자 주문 상태 변경 API 추가
  - `AdminOrderController`에 `POST /admin/orders/{orderId}/change-status` 엔드포인트를 추가했습니다.
  - `OrderStatusUpdateRequest` DTO를 통해 변경할 주문 상태를 전달받도록 구성했습니다.
  - `OrderService`에 `changeOrderStatus` 비즈니스 로직을 구현하여 실제 상태 변경을 수행합니다.

- 도메인 모델 개선
  - `Order` 엔티티에 `changeStatus` 메서드를 추가하여 상태 변경 규칙을 도메인 내부에서 캡슐화했습니다.
  - `OrderStatus` 열거형에 `PREPARING`(배송 준비중)을 추가하고, 기존 `SHIPPED` 값을 `SHIPPING`으로 명확하게 변경했습니다.

- API 문서화
  - 신규 API에 Swagger 관련 어노테이션을 적용하여 문서화했습니다.