### PR TITLE
feat(order): KAN-31 [주문] 주문 취소 관리자 승인·이력 관리 API 구현

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "필수값 누락입니다."),
 	FAIL_ACQUIRED_LOCK(HttpStatus.BAD_REQUEST, "락 획득에 실패했습니다."),
 	ERROR_SYSTEM(HttpStatus.INTERNAL_SERVER_ERROR, "시스템 오류가 발생했습니다."),
+	INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태입니다."),
+	REASON_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, "사유는 비워둘 수 없습니다."),
 	ALREADY_PAID_ORDER(HttpStatus.BAD_REQUEST, "이미 결제된 주문입니다.");
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -128,22 +128,23 @@ public class OrderController extends SwaggerAssistance {
     }
 
 	@Operation(
-		summary = "주문 취소",
-		description = "특정 주문을 취소합니다. 관리자 또는 주문자 본인만 취소 가능합니다."
+		summary = "주문 취소 요청",
+		description = "사용자가 자신의 주문에 대해 취소를 요청합니다. 관리자의 승인이 필요합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "주문 취소 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))),
+		@ApiResponse(responseCode = "200", description = "주문 취소 요청 성공"),
+		@ApiResponse(responseCode = "400", description = "취소 요청이 불가능한 주문 상태입니다."),
 		@ApiResponse(responseCode = "401", description = "인증 실패"),
-		@ApiResponse(responseCode = "403", description = "취소 권한 없음"),
+		@ApiResponse(responseCode = "403", description = "취소 요청 권한 없음"),
 		@ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음")
 	})
 	@PostMapping("/{orderId}/cancel")
-	public ApiResult<Void> cancelOrder(
+	public ApiResult<Void> requestCancel(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
-        @Parameter(description = "취소할 주문 ID", example = "1")
+        @Parameter(description = "취소 요청할 주문 ID", example = "1")
 		@PathVariable Long orderId
 	) {
-		orderService.cancelOrder(orderId, currentUser);
+		orderService.requestCancelByUser(orderId, currentUser);
 		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/domain/order/Order.java
+++ b/src/main/java/com/kt/domain/order/Order.java
@@ -20,6 +20,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @Getter
 @Entity
@@ -28,15 +29,17 @@ import lombok.NoArgsConstructor;
 public class Order extends BaseEntity {
 	@Embedded
 	private Receiver receiver;
+
 	@Enumerated(EnumType.STRING)
 	private OrderStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus previousStatus;
+
+    private String cancelDecisionReason;
+
 	private LocalDateTime deliveredAt;
 
-	// 연관관계
-	// 주문 <-> 회원
-	// N : 1 => 다대일
-	// ManyToOne
-	// FK => 많은 쪽에 생김
 	@ManyToOne
 	@JoinColumn(name = "user_id")
 	private User user;
@@ -70,10 +73,31 @@ public class Order extends BaseEntity {
         return this.status == OrderStatus.PENDING || this.status == OrderStatus.COMPLETED;
     }
 
-	public void cancel() {
-		Preconditions.validate(this.status == OrderStatus.PENDING, ErrorCode.CANNOT_CANCEL_ORDER);
-		this.status = OrderStatus.CANCELLED;
-	}
+    public void requestCancel() {
+        Preconditions.validate(this.status ==
+						OrderStatus.PENDING || this.status == OrderStatus.COMPLETED,
+				ErrorCode.CANNOT_CANCEL_ORDER);
+        this.previousStatus = this.status;
+        this.status = OrderStatus.CANCEL_REQUESTED;
+    }
+
+    public void approveCancel(String reason) {
+        Preconditions.validate(isCancelRequestableByAdmin(), ErrorCode.INVALID_ORDER_STATUS);
+        Preconditions.validate(StringUtils.hasText(reason), ErrorCode.REASON_CANNOT_BE_EMPTY);
+        this.status = OrderStatus.CANCELLED;
+        this.cancelDecisionReason = reason;
+    }
+
+    public void rejectCancel(String reason) {
+        Preconditions.validate(isCancelRequestableByAdmin(), ErrorCode.INVALID_ORDER_STATUS);
+        Preconditions.validate(StringUtils.hasText(reason), ErrorCode.REASON_CANNOT_BE_EMPTY);
+        this.status = this.previousStatus;
+        this.cancelDecisionReason = reason;
+    }
+
+    public boolean isCancelRequestableByAdmin() {
+        return this.status == OrderStatus.CANCEL_REQUESTED;
+    }
 
 	public long getTotalPrice() {
 		return orderProducts.stream()
@@ -85,18 +109,8 @@ public class Order extends BaseEntity {
 		this.status = OrderStatus.COMPLETED;
 	}
 
-	public void changeStatus(OrderStatus orderStatus){
-		this.status = orderStatus;
-	}
+	// public void changeStatus(OrderStatus orderStatus){
+	// 	this.status = orderStatus;
+	// }
 
-	//하나의 오더는 여러개의 상품을 가질수있음
-	// 1:N
-	//하나의 상품은 여러개의 오더를 가질수있음
-	// 1:N
-
-	// 주문생성
-	// 주문상태변경
-	// 주문생성완료재고차감
-	// 배송받는사람정보변경
-	// 주문취소
 }

--- a/src/main/java/com/kt/domain/order/OrderCancelDecision.java
+++ b/src/main/java/com/kt/domain/order/OrderCancelDecision.java
@@ -1,0 +1,13 @@
+package com.kt.domain.order;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderCancelDecision {
+    APPROVE("승인"),
+    REJECT("반려");
+
+    private final String description;
+}

--- a/src/main/java/com/kt/domain/order/OrderStatus.java
+++ b/src/main/java/com/kt/domain/order/OrderStatus.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum OrderStatus {
 	PENDING("결제대기"),
 	COMPLETED("결제완료"),
+	CANCEL_REQUESTED("취소요청"),
 	CANCELLED("주문취소"),
 	PREPARING("배송준비중"),
 	SHIPPING("배송중"),

--- a/src/main/java/com/kt/dto/order/OrderCancelDecisionRequest.java
+++ b/src/main/java/com/kt/dto/order/OrderCancelDecisionRequest.java
@@ -1,0 +1,12 @@
+package com.kt.dto.order;
+
+import com.kt.domain.order.OrderCancelDecision;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OrderCancelDecisionRequest(
+    @NotNull
+    OrderCancelDecision decision,
+    String reason
+) {
+}

--- a/src/main/java/com/kt/repository/order/OrderRepository.java
+++ b/src/main/java/com/kt/repository/order/OrderRepository.java
@@ -11,6 +11,7 @@ import com.kt.common.exception.CustomException;
 import com.kt.common.exception.ErrorCode;
 import com.kt.domain.order.Order;
 
+import com.kt.domain.order.OrderStatus;
 import jakarta.validation.constraints.NotNull;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
@@ -18,6 +19,16 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
 	@NotNull
 	@EntityGraph(attributePaths = {"orderProducts", "orderProducts.product"})
 	Page<Order> findAllByUserId(Long userId, Pageable pageable);
+
+	/**
+	 * 지정된 주문 상태(OrderStatus)에 해당하는 주문 목록을 페이징하여 조회합니다.
+	 *
+	 * @param status   조회할 주문 상태
+	 * @param pageable 페이징 정보 (페이지 번호, 페이지 크기, 정렬 등)
+	 * @return 페이징 처리된 주문(Order) 목록
+	 */
+	@EntityGraph(attributePaths = {"orderProducts", "orderProducts.product", "user"})
+	Page<Order> findAllByStatus(OrderStatus status, Pageable pageable);
 
 	// 주문 상세 조회
 	@EntityGraph(attributePaths = {"orderProducts", "orderProducts.product", "user"})


### PR DESCRIPTION
## 🔧 구현 내용

  기존에 사용자/관리자 역할을 겸하던 주문 취소 API(POST /orders/{orderId}/cancel)를 명세에 따라 역할별로 분리하고, 관리자용 주문 취소 처리 기능을 구체화했습니다.

   - 주문 취소 API 역할 분리
       - (사용자) POST /orders/{orderId}/cancel: 사용자가 직접 취소를 '요청'하는 기능으로 역할을 명확히 했습니다.
       - (관리자) POST /admin/orders/{orderId}/cancel: 관리자가 취소 요청을 '처리'(승인/거절)하는 기능으로 신규 구현했습니다.

   - 관리자 주문 취소 처리 기능 상세 구현
       - OrderService.decideCancel 비즈니스 로직을 통해 취소 요청을 '승인' 또는 '거절'할 수 있습니다.
       - 취소 승인 시, StockService와 연동하여 상품 재고를 자동으로 복구하도록 구현했습니다.
       - Order 엔티티에 approveCancel, rejectCancel 등 상태 전이 로직을 추가하여 도메인 규칙을 강화했습니다.
       - 관리자의 취소 결정을 전달하기 위한 OrderCancelDecisionRequest DTO와 OrderCancelDecision Enum을 새로 생성했습니다.

   - 관리자 주문 취소 요청 목록 조회 API 추가
       - OrderStatus가 CANCEL_REQUESTED인 주문 목록을 페이징하여 조회하는 GET /admin/orders/cancel API를 구현했습니다.

##  📌 관련 Jira Issue
   - KAN-31

##  🧪 테스트 방법

   1. 사용자 주문 취소 요청 (테스트 준비)
       - 임의의 사용자로 로그인하여 주문을 생성한 후, 해당 주문 ID로 아래 API를 호출하여 주문 상태를 CANCEL_REQUESTED로 변경합니다.
       - Endpoint: POST /orders/{orderId}/cancel
       - Authorization: Bearer {user_token}

   2. 관리자 주문 취소 요청 목록 조회
       - Endpoint: GET /admin/orders/cancel
       - Authorization: Bearer {admin_token}
       - 파라미터: page=0, size=10
       - 체크 포인트: 1번에서 요청한 주문이 목록에 포함되어 있는지, 상태가 CANCEL_REQUESTED로 표시되는지 확인합니다.

   3. 관리자 주문 취소 처리 (승인)
       - Endpoint: POST /admin/orders/{orderId}/cancel (1번에서 사용한 orderId)
       - Authorization: Bearer {admin_token}
       - Request Body:
```
 {
       "decision": "APPROVE",
       "reason": "고객 요청으로 인한 취소 승인"
      }
````

       - 체크 포인트:
           - API가 200 OK를 반환하는지 확인합니다.
           - GET /admin/orders/{orderId}로 상세 조회 시, 주문 상태가 CANCELLED로 변경되었는지 확인합니다.
           - 해당 상품의 재고가 주문 수량만큼 다시 증가했는지 확인합니다.

   4. 관리자 주문 취소 처리 (거절)
       - Endpoint: POST /admin/orders/{orderId}/cancel (1번에서 사용한 orderId)
       - Authorization: Bearer {admin_token}
       - Request Body:
```
       {
         "decision": "REJECT",
         "reason": "취소 불가능한 상품입니다."
       }
```

       - 체크 포인트:
           - API가 200 OK를 반환하는지 확인합니다.
           - GET /admin/orders/{orderId}로 상세 조회 시, 주문 상태가 취소 요청 이전의 상태(예: PENDING)로 돌아왔는지 확인합니다.

##  ❗ 기타 참고 사항

   - 실제 결제 시스템과 연동하는 환불 처리 로직은 본 PR의 범위에 포함되지 않으며, 추후 구현될 예정입니다.
   - 로컬 DB에서 orders 테이블의 status ENUM 값 중 CANCEL_REQUESTED, PREPARING 항목이 누락되어 있으면 Data truncated for column 'status' 오류가 발생합니다.!!!!!!
각자 로컬 환경에서도 ENUM 값을 동일하게 추가하거나, 컬럼을 업데이트하여 develop 브랜치의 최신 DDL과 맞춰주시기 바랍니다.