### PR TITLE
feat(Product): KAN-41 정렬 기반 상품 조회 API 구현

### DIFF
--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.common.support.SwaggerAssistance;
+import com.kt.domain.product.ProductSortType;
 import com.kt.dto.product.ProductRequest;
 import com.kt.dto.product.ProductResponse;
 import com.kt.service.ProductService;
@@ -37,16 +38,18 @@ public class AdminProductController extends SwaggerAssistance {
 
 	@Operation(summary = "상품 검색 및 조회", description = "전체 상품 목록을 검색 및 조회합니다. 키워드를 입력하지 않으면 전체 상품이 조회됩니다.",
 			parameters = {
-					@Parameter(name = "keyword", description = "검색 키워드", example = ""),
+					@Parameter(name = "keyword", description = "검색 키워드"),
+					@Parameter(name = "sortType", description = "정렬 기준(LATEST, POPULAR)", example = "LATEST"),
 					@Parameter(name = "page", description = "페이지 번호", example = "1"),
 					@Parameter(name = "size", description = "페이지 크기", example = "10")
 			})
 	@GetMapping
 	public ApiResult<Page<ProductResponse.AdminSummary>> search(
 			@RequestParam(required = false) String keyword,
+			@RequestParam(required = false) ProductSortType sortType,
 			@Parameter(hidden = true) Paging paging
 	) {
-		var search = productService.searchNonDeletedStatus(keyword, paging.toPageable())
+		var search = productService.searchNonDeletedStatus(keyword, sortType, paging.toPageable())
 				.map(ProductResponse.AdminSummary::of);
 
 		return ApiResult.ok(search);

--- a/src/main/java/com/kt/controller/product/ProductController.java
+++ b/src/main/java/com/kt/controller/product/ProductController.java
@@ -13,6 +13,7 @@ import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.common.support.ProductViewEvent;
 import com.kt.common.support.SwaggerAssistance;
+import com.kt.domain.product.ProductSortType;
 import com.kt.dto.product.ProductResponse;
 import com.kt.security.CurrentUser;
 import com.kt.service.ProductService;
@@ -36,16 +37,18 @@ public class ProductController extends SwaggerAssistance {
 
 	@Operation(summary = "상품 검색 및 조회", description = "활성화, 품절 상태인 전체 상품 목록을 검색 및 조회합니다. 키워드를 입력하지 않으면 전체 상품이 조회됩니다.",
 			parameters = {
-					@Parameter(name = "keyword", description = "검색 키워드", example = ""),
+					@Parameter(name = "keyword", description = "검색 키워드"),
+					@Parameter(name = "sortType", description = "정렬 기준(LATEST, POPULAR)", example = "LATEST"),
 					@Parameter(name = "page", description = "페이지 번호", example = "1"),
 					@Parameter(name = "size", description = "페이지 크기", example = "10")
 			})
 	@GetMapping
 	public ApiResult<Page<ProductResponse.Summary>> search(
 			@RequestParam(required = false) String keyword,
+			@RequestParam(required = false) ProductSortType sortType,
 			@Parameter(hidden = true) Paging paging
 	) {
-		var search = productService.searchPublicStatus(keyword, paging.toPageable())
+		var search = productService.searchPublicStatus(keyword, sortType, paging.toPageable())
 				.map(ProductResponse.Summary::of);
 
 		return ApiResult.ok(search);

--- a/src/main/java/com/kt/domain/product/ProductSortType.java
+++ b/src/main/java/com/kt/domain/product/ProductSortType.java
@@ -1,0 +1,16 @@
+package com.kt.domain.product;
+
+import org.springframework.data.domain.Sort;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductSortType {
+	LATEST("createdAt", Sort.Direction.DESC),
+	POPULAR("viewCount", Sort.Direction.DESC);
+
+	private final String FieldName;
+	private final Sort.Direction direction;
+}

--- a/src/main/java/com/kt/service/ProductService.java
+++ b/src/main/java/com/kt/service/ProductService.java
@@ -4,12 +4,15 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.kt.domain.product.Product;
+import com.kt.domain.product.ProductSortType;
 import com.kt.domain.product.ProductStatus;
 import com.kt.dto.product.ProductRequest;
 import com.kt.repository.product.ProductRepository;
@@ -33,24 +36,35 @@ public class ProductService {
 		productRepository.save(request.toEntity());
 	}
 
-	public Page<Product> searchPublicStatus(String keyword, Pageable pageable) {
+	public Page<Product> searchPublicStatus(String keyword, ProductSortType sortType, Pageable pageable) {
 		String searchKeyword = StringUtils.hasText(keyword) ? keyword : "";
+		Pageable sortedPageable = createSortedPageable(pageable, sortType);
 
 		return productRepository.findAllByKeywordAndStatuses(
 				searchKeyword,
 				PUBLIC_VIEWABLE_STATUS,
-				pageable
+				sortedPageable
 		);
 	}
 
-	public Page<Product> searchNonDeletedStatus(String keyword, Pageable pageable) {
+	public Page<Product> searchNonDeletedStatus(String keyword, ProductSortType sortType, Pageable pageable) {
 		String searchKeyword = StringUtils.hasText(keyword) ? keyword : "";
+		Pageable sortedPageable = createSortedPageable(pageable, sortType);
 
 		return productRepository.findAllByKeywordAndStatuses(
 				searchKeyword,
 				NON_DELETED_STATUS,
-				pageable
+				sortedPageable
 		);
+	}
+
+	private Pageable createSortedPageable(Pageable pageable, ProductSortType sortType) {
+		return (sortType != null) ?
+				PageRequest.of(
+						pageable.getPageNumber(),
+						pageable.getPageSize(),
+						Sort.by(sortType.getDirection(), sortType.getFieldName())
+				) : pageable;
 	}
 
 	public Product detail(Long id) {

--- a/src/test/java/com/kt/service/ProductServiceTest.java
+++ b/src/test/java/com/kt/service/ProductServiceTest.java
@@ -67,7 +67,7 @@ public class ProductServiceTest {
 		Pageable pageable = PageRequest.of(0, 10);
 
 		// When
-		productService.searchPublicStatus(keyword, pageable);
+		productService.searchPublicStatus(keyword, null, pageable);
 
 		// Then
 		Mockito.verify(productRepository).findAllByKeywordAndStatuses(


### PR DESCRIPTION
### 작업사항

**최신순, 조회순 정렬 상품 조회 API 구현**

- domain/product/ProductSortType: 정렬 기준을 저장하는 Enum 파일을 생성했습니다.
- service/ProductService: 정렬 조건이 존재할 경우, 정렬 기준을 포함한 새로운 Pageable 변수를 생성하는 메서드를 구현했으며, 기존 검색 메서드를 업데이트했습니다.
- controller/ProductController, AdminProductController: 상품 목록 조회시 정렬 기준을 파라미터로 받아오도록 변경했습니다. 이에 따라 Swagger 문서도 업데이트했습니다.
  