### PR TITLE
feat(order): KAN-71 [주문] 관리자 주문 상태변경 기능 복원

### DIFF
--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import com.kt.domain.order.OrderStatus;
+import com.kt.dto.order.OrderStatusUpdateRequest;
 
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
@@ -124,6 +125,25 @@ public class AdminOrderController extends SwaggerAssistance {
 		@Valid @RequestBody OrderCancelDecisionRequest request
 	) {
 		orderService.decideCancel(orderId, request);
+		return ApiResult.ok();
+	}
+
+	@Operation(
+		summary = "관리자 주문 상태 변경",
+		description = "관리자가 주문 ID로 특정 주문의 상태를 변경합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+		@ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음"),
+	})
+	@PostMapping("/{orderId}/change-status")
+	@SecurityRequirement(name = "Bearer Authentication")
+	public ApiResult<Void> changeStatus(
+		@Parameter(description = "상태를 변경할 주문 ID", required = true)
+		@PathVariable Long orderId,
+		@RequestBody OrderStatusUpdateRequest request
+	) {
+		orderService.changeOrderStatus(orderId, request);
 		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/domain/order/Order.java
+++ b/src/main/java/com/kt/domain/order/Order.java
@@ -111,8 +111,8 @@ public class Order extends BaseEntity {
 		this.status = OrderStatus.COMPLETED;
 	}
 
-	// public void changeStatus(OrderStatus orderStatus){
-	// 	this.status = orderStatus;
-	// }
+	public void changeStatus(OrderStatus orderStatus){
+		this.status = orderStatus;
+	}
 
 }

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -187,8 +187,8 @@ public class OrderService {
 		);
 	}
 
-	// public void changeOrderStatus(Long orderId, OrderStatusUpdateRequest request) {
-	// 	Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
-	// 	order.changeStatus(request.status());
-	// }
+	public void changeOrderStatus(Long orderId, OrderStatusUpdateRequest request) {
+		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		order.changeStatus(request.status());
+	}
 }


### PR DESCRIPTION
주문 취소 처리 구현 과정에서 상태 변경 기능의 위치가 모호해져 임시로 주석 처리했던 관리자의 주문 상태 변경 API를 다시 활성화했습니다. 기존 흐름과 충돌 없이 독립적으로 동작한다고 생각해서 복원했습니다 (필수 명세에 있던거라 다시 복원했슴다 ㅎㅎ)