### PR TITLE
feat(admin): KAN-77 관리자 사용자 관리 기능 구현 (수정, 삭제, 비밀번호 초기화)

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 	NOT_MATCHED_CHECK_PASSWORD(HttpStatus.BAD_REQUEST, "입력한 비밀번호가 서로 다릅니다. 다시 확인해주세요."),
 	ALREADY_HAS_ROLE(HttpStatus.BAD_REQUEST, "이미 관리자 권한을 가지고 있는 회원입니다."),
 	USER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 없는 회원입니다."),
+	CANNOT_DELETE_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 삭제할 수 없습니다."),
 	CANNOT_UPDATE_ORDER(HttpStatus.BAD_REQUEST, "주문을 수정할 수 없는 상태입니다."),
 	CANNOT_CANCEL_ORDER(HttpStatus.BAD_REQUEST, "주문을 취소할 수 없는 상태입니다."),
 	NO_AUTHORITY_TO_CANCEL_ORDER(HttpStatus.FORBIDDEN, "주문을 취소할 권한이 없습니다."),

--- a/src/main/java/com/kt/controller/user/AdminController.java
+++ b/src/main/java/com/kt/controller/user/AdminController.java
@@ -6,6 +6,8 @@ import com.kt.common.response.ApiResult;
 import com.kt.common.support.Preconditions;
 import com.kt.dto.user.UserCreateRequest;
 import com.kt.dto.user.UserResponse;
+import com.kt.dto.user.UserUpdateRequest;
+import com.kt.security.CurrentUser;
 import com.kt.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -72,5 +75,69 @@ public class AdminController {
         var user = userService.detail(id);
         Preconditions.validate(user.getRole() == com.kt.domain.user.Role.ADMIN, ErrorCode.USER_NOT_ADMIN);
         return ApiResult.ok(UserResponse.Detail.of(user));
+    }
+
+    @Operation(
+            summary = "관리자 정보 수정",
+            description = "관리자가 특정 관리자의 정보를 수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음")
+    })
+    @PutMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<UserResponse.Detail> updateAdmin(
+            @Parameter(description = "수정할 관리자 ID", required = true)
+            @PathVariable Long id,
+            @RequestBody @Valid UserUpdateRequest request
+    ) {
+        var user = userService.detail(id);
+        Preconditions.validate(user.getRole() == com.kt.domain.user.Role.ADMIN, ErrorCode.USER_NOT_ADMIN);
+        var updatedUser = userService.update(id, request.name(), request.email(), request.mobile());
+        return ApiResult.ok(updatedUser);
+    }
+
+    @Operation(
+            summary = "관리자 삭제 (비활성화)",
+            description = "관리자가 특정 관리자 계정을 비활성화(소프트 삭제)합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음"),
+            @ApiResponse(responseCode = "400", description = "자기 자신을 삭제할 수 없음")
+    })
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<Void> deleteAdmin(
+            @AuthenticationPrincipal CurrentUser currentUser,
+            @Parameter(description = "삭제할 관리자 ID", required = true)
+            @PathVariable Long id
+    ) {
+        Preconditions.validate(!currentUser.getId().equals(id), ErrorCode.CANNOT_DELETE_SELF);
+        var user = userService.detail(id);
+        Preconditions.validate(user.getRole() == com.kt.domain.user.Role.ADMIN, ErrorCode.USER_NOT_ADMIN);
+        userService.deactivateUser(id);
+        return ApiResult.ok();
+    }
+
+    @Operation(
+            summary = "관리자 비밀번호 초기화",
+            description = "관리자가 특정 관리자의 비밀번호를 임시 비밀번호로 초기화하고, 임시 비밀번호를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "초기화 성공"),
+            @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음")
+    })
+    @PostMapping("/{id}/init-password")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<String> initAdminPassword(
+            @Parameter(description = "비밀번호를 초기화할 관리자 ID", required = true)
+            @PathVariable Long id
+    ) {
+        var user = userService.detail(id);
+        Preconditions.validate(user.getRole() == com.kt.domain.user.Role.ADMIN, ErrorCode.USER_NOT_ADMIN);
+        String tempPassword = userService.initPassword(id);
+        return ApiResult.ok(tempPassword);
     }
 }

--- a/src/main/java/com/kt/service/UserService.java
+++ b/src/main/java/com/kt/service/UserService.java
@@ -121,6 +121,10 @@ public class UserService {
 		return userRepository.findByIdOrThrow(id);
 	}
 
+	public User detailIncludeDeleted(Long id) {
+		return userRepository.findByIdIncludeDeletedOrThrow(id);
+	}
+
 	@Transactional
 	public UserResponse.Detail update(Long id, String name, String email, String mobile) {
 		var user = userRepository.findByIdOrThrow(id);
@@ -186,5 +190,14 @@ public class UserService {
 	public void revokeAdminRole(Long id) {
 		var user = userRepository.findByIdOrThrow(id);
 		user.revokeAdminRole();
+	}
+
+	@Transactional
+	public String initPassword(Long userId) {
+		User user = userRepository.findByIdOrThrow(userId);
+		String tempPassword = java.util.UUID.randomUUID().toString().substring(0, 8); // e.g., "123e4567"
+		String encodedPassword = passwordEncoder.encode(tempPassword);
+		user.changePassword(encodedPassword);
+		return tempPassword;
 	}
 }


### PR DESCRIPTION
- 관리자 정보 수정 (PUT /admin/admins/{id})
  - 관리자가 다른 관리자 사용자의 상세 정보를 수정할 수 있습니다
  - 대상 사용자가 실제로 관리자인지 확인하는 유효성 검사를 포함합니다.

- 관리자 계정 삭제 (DELETE /admin/admins/{id})
  - 관리자가 다른 관리자 계정을 비활성화(소프트 삭제)할 수 있습니다
  - 관리자가 자신의 계정을 삭제하지 못하도록 구현했습니다
  - 대상 사용자가 관리자인지 유효성 검사를 수행합니다.

- 관리자 비밀번호 초기화 (POST /admin/admins/{id}/init-password)
  - 관리자가 다른 관리자 사용자의 비밀번호를 임시 비밀번호로 초기화할 수 있습니다
  - 생성된 임시 비밀번호를 호출한 관리자에게 반환합니다.
  - 대상 사용자가 관리자인지 확인합니다.