### PR TITLE
feat(admin): KAN-74 [관리자] 사용자 비밀번호 변경 및 초기화 API 구현

### DIFF
--- a/src/main/java/com/kt/controller/user/AdminUserController.java
+++ b/src/main/java/com/kt/controller/user/AdminUserController.java
@@ -1,14 +1,10 @@
 package com.kt.controller.user;
 
-import com.kt.domain.user.Role;
-import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.common.support.SwaggerAssistance;
+import com.kt.dto.user.UserChangePasswordRequest;
 import com.kt.dto.user.UserResponse;
 import com.kt.dto.user.UserUpdateRequest;
 import com.kt.security.CurrentUser;
@@ -22,6 +18,19 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Admin-User", description = "관리자 사용자 관리 API")
 @RestController
@@ -150,16 +159,50 @@ public class AdminUserController extends SwaggerAssistance {
             @ApiResponse(responseCode = "200", description = "사용자 활성화 성공"),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    @PutMapping("/{id}/in-activate")
+    @PutMapping("/{id}/activate")
     @ResponseStatus(HttpStatus.OK)
     public ApiResult<Void> activateUser(
             @Parameter(description = "활성화할 사용자 ID", required = true)
-            @PathVariable Long id
+            @PathVariable("id") Long userId
     ) {
-        userService.activateUser(id);
+        userService.activateUser(userId);
         return ApiResult.ok();
     }
-    // 유저 삭제
-    // DELETE FROM MEMBER WHERE id = ?
-    // 유저 비밀번호 초기화
+
+    @Operation(
+            summary = "사용자 비밀번호 초기화",
+            description = "관리자가 사용자의 비밀번호를 임시 비밀번호로 초기화합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 초기화 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @PostMapping("/{user_id}/init-password")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<String> initPassword(
+            @Parameter(description = "초기화할 사용자 ID", required = true)
+            @PathVariable("user_id") Long userId
+    ) {
+        String temporaryPassword = userService.initPassword(userId);
+        return ApiResult.ok("임시 비밀번호: " + temporaryPassword);
+    }
+
+    @Operation(
+            summary = "사용자 비밀번호 변경",
+            description = "관리자가 특정 사용자의 비밀번호를 직접 변경합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @PutMapping("/{user_id}/change-password")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<Void> changePassword(
+            @Parameter(description = "변경할 사용자 ID", required = true)
+            @PathVariable("user_id") Long userId,
+            @RequestBody @Valid UserChangePasswordRequest request
+    ) {
+        userService.changePasswordByAdmin(userId, request);
+        return ApiResult.ok();
+    }
 }

--- a/src/main/java/com/kt/dto/user/UserChangePasswordRequest.java
+++ b/src/main/java/com/kt/dto/user/UserChangePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.kt.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+public record UserChangePasswordRequest(
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        String newPassword
+) {
+    @Builder
+    public UserChangePasswordRequest {
+    }
+}


### PR DESCRIPTION
**사용자 비밀번호 변경 API:**
- 관리자가 특정 사용자의 비밀번호를 직접 새로 설정할 수 있는 API를 구현했습니다. **사용자 비밀번호 초기화 API:**
- 관리자가 사용자의 비밀번호를 안전한 임시 비밀번호로 초기화하고, 생성된 임시 비밀번호를 반환하는 API를 구현했습니다.

주요 변경 사항:
-   `AdminUserController`:
    -   `PUT /admin/users/{user_id}/change-password`: 사용자 비밀번호 변경 API 엔드포인트 추가
    -   `POST /admin/users/{user_id}/init-password`: 사용자 비밀번호 초기화 API 엔드포인트 추가
-   `UserService`:
    -   `changePasswordByAdmin()`: 관리자의 비밀번호 변경 요청을 처리하는 로직 추가
    -   `initPassword()`: 임시 비밀번호를 생성하고 사용자 비밀번호를 업데이트하는 로직 추가
    -   `generateRandomPassword()`: 보안 강화를 위해 영문 대/소문자, 숫자, 특수문자를 포함하는 8자리 임시 비밀번호 생성 로직 구현
-   `UserChangePasswordRequest`:
    -   관리자의 비밀번호 변경 요청을 위한 DTO 추가