### PR TITLE
fix(ci): GitHub Actions 환경변수 오타 수정 및 Slack Webhook 변수명 정리

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   DB_PASSWORD: root
-  SLACK_WEB_HOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 jobs:
   dev-deploy:


### PR DESCRIPTION
### 🔧 변경 내용
* `set env` 단계에서 `$GITHUB_EN` → `$GITHUB_ENV` 로 오타 수정
* Slack Webhook 환경변수명을 `SLACK_WEBHOOK_URL` 로 일원화
* GitHub Secrets와 env 변수 이름을 동일하게 맞춰 deploy 단계 오류 방지
* dev-deploy workflow가 정상적으로 실행될 수 있도록 CI 수정

### 🐞 문제 원인

* `$GITHUB_ENV` 오타로 인해 env 파일 write 실패 → 이후 단계 미실행
* Slack 알림 단계에서 `SLACK_WEB_HOOK_URL` 변수 mismatching 발생

### 📌 테스트
* 수정 후 dev 브랜치 push → workflow 정상 trigger 확인 예정
