### PR TITLE
refactor(review): KAN-82 [리뷰] 수정/삭제 공통 검증 로직 분리 및 delete 로직 개선

### DIFF
--- a/src/main/java/com/kt/service/ReviewService.java
+++ b/src/main/java/com/kt/service/ReviewService.java
@@ -65,21 +65,13 @@ public class ReviewService {
 	}
 
 	public void updateReview(Long reviewId, Long userId, ReviewUpdateRequest request) {
-		Review review = reviewRepository.findByIdOrThrow(reviewId);
-
-		// 1. 리뷰 작성자가 맞는지 확인
-		Preconditions.validate(review.getUser().getId().equals(userId), ErrorCode.NO_AUTHORITY_TO_UPDATE_REVIEW);
-
+		Review review = findReviewByIdAndValidateOwner(reviewId, userId, ErrorCode.NO_AUTHORITY_TO_UPDATE_REVIEW);
 		review.update(request.getContent(), request.getRating());
 	}
 
 	public void deleteReview(Long reviewId, Long userId) {
-		Review review = reviewRepository.findByIdOrThrow(reviewId);
-
-		// 1. 리뷰 작성자가 맞는지 확인
-		Preconditions.validate(review.getUser().getId().equals(userId), ErrorCode.NO_AUTHORITY_TO_DELETE_REVIEW);
-
-		reviewRepository.deleteById(reviewId);
+		Review review = findReviewByIdAndValidateOwner(reviewId, userId, ErrorCode.NO_AUTHORITY_TO_DELETE_REVIEW);
+		reviewRepository.delete(review);
 	}
 
 	@Transactional(readOnly = true)
@@ -92,5 +84,11 @@ public class ReviewService {
 		reviewRepository.findByIdOrThrow(reviewId);
 
 		reviewRepository.deleteById(reviewId);
+	}
+
+	private Review findReviewByIdAndValidateOwner(Long reviewId, Long userId, ErrorCode errorCode) {
+		Review review = reviewRepository.findByIdOrThrow(reviewId);
+		Preconditions.validate(review.getUser().getId().equals(userId), errorCode);
+		return review;
 	}
 }


### PR DESCRIPTION
### 🔧 구현 내용
- 리뷰 수정/삭제 시 반복되던 `findById + 사용자 검증` 로직을 `findReviewByIdAndValidateOwner()` 메소드로 공통화하여 중복 제거
- `deleteById(reviewId)` 대신 `delete(review)` 방식으로 변경하여 조회된 엔티티 활용 및 영속성 컨텍스트 일관성 강화
- 관리자 삭제 로직의 예외 처리 방식 유지(추후 동일 패턴으로 리팩터링 가능성 고려)

### 📌 관련 Jira Issue
- KAN-82

### 🧪 테스트 방법
- 리뷰 수정 요청: 본인 계정일 경우 정상 수정, 타 계정 요청 시 403 발생 여부 확인
- 리뷰 삭제 요청: 본인 계정일 경우 정상 삭제, 타 계정 요청 시 403 발생 여부 확인
- 관리자 삭제 요청: 존재하지 않는 리뷰 ID 요청 시 NOT_FOUND_REVIEW 예외 발생 확인