### PR TITLE
test(refund): KAN-95 [환불/반품] Service 테스트 코드 작성

### DIFF
--- a/src/main/java/com/kt/dto/refund/RefundRejectRequest.java
+++ b/src/main/java/com/kt/dto/refund/RefundRejectRequest.java
@@ -1,11 +1,13 @@
 package com.kt.dto.refund;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class RefundRejectRequest {
 
     @NotBlank(message = "거절 사유를 입력해주세요.")

--- a/src/main/java/com/kt/dto/refund/RefundRequest.java
+++ b/src/main/java/com/kt/dto/refund/RefundRequest.java
@@ -3,11 +3,13 @@ package com.kt.dto.refund;
 import com.kt.domain.refund.RefundType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class RefundRequest {
 
     @NotNull(message = "환불/반품 타입을 선택해주세요.")

--- a/src/test/java/com/kt/service/RefundServiceTest.java
+++ b/src/test/java/com/kt/service/RefundServiceTest.java
@@ -1,0 +1,375 @@
+package com.kt.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
+import com.kt.domain.order.Order;
+import com.kt.domain.order.OrderStatus;
+import com.kt.domain.order.Receiver;
+import com.kt.domain.orderproduct.OrderProduct;
+import com.kt.domain.product.Product;
+import com.kt.domain.refund.RefundStatus;
+import com.kt.domain.refund.RefundType;
+import com.kt.domain.user.Gender;
+import com.kt.domain.user.Role;
+import com.kt.domain.user.User;
+import com.kt.dto.refund.RefundRejectRequest;
+import com.kt.dto.refund.RefundRequest;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.refund.RefundRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RefundServiceTest {
+
+	@Autowired
+	private OrderService orderService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+
+	@Autowired
+	private RefundRepository refundRepository;
+
+	private User testUser;
+	private Product testProduct;
+	private Order testOrder;
+
+	@BeforeEach
+	void setUp() {
+		refundRepository.deleteAll();
+		orderProductRepository.deleteAll();
+		orderRepository.deleteAll();
+		productRepository.deleteAll();
+		userRepository.deleteAll();
+
+		// 테스트용 사용자 생성
+		testUser = userRepository.save(
+			new User(
+				"testuser",
+				"password",
+				"Test User",
+				"test@email.com",
+				"010-0000-0000",
+				Gender.MALE,
+				LocalDate.now(),
+				LocalDateTime.now(),
+				LocalDateTime.now(),
+				Role.CUSTOMER
+			)
+		);
+
+		// 테스트용 상품 생성
+		testProduct = productRepository.save(
+			new Product(
+				"테스트 상품",
+				100_000L,
+				10L,
+				"상품 상세설명"
+			)
+		);
+
+		// 테스트용 주문 생성
+		testOrder = orderRepository.save(
+			Order.create(
+				new Receiver("수신자", "주소", "010-1111-2222"),
+				testUser
+			)
+		);
+
+		// 주문 상품 생성
+		OrderProduct orderProduct = orderProductRepository.save(
+			new OrderProduct(testOrder, testProduct, 2L)
+		);
+
+		testOrder.mapToOrderProduct(orderProduct);
+		testProduct.mapToOrderProduct(orderProduct);
+		testProduct.decreaseStock(2L);
+	}
+
+	@Test
+	@DisplayName("환불 요청 성공 - 배송중 상태")
+	void 환불_요청_성공() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder); // DB에 변경사항 반영
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+
+		// when
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		// then
+		var refund = refundRepository.findAll().get(0);
+		assertThat(refund.getStatus()).isEqualTo(RefundStatus.REFUND_REQUESTED);
+		assertThat(refund.getType()).isEqualTo(RefundType.REFUND);
+		assertThat(refund.getReason()).isEqualTo("단순 변심");
+		assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.ORDER_SHIPPING); // Order 상태는 변경되지 않음
+	}
+
+	@Test
+	@DisplayName("반품 요청 성공 - 배송완료 상태")
+	void 반품_요청_성공() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_DELIVERED);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.RETURN, "상품 불량");
+
+		// when
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		// then
+		var refund = refundRepository.findAll().get(0);
+		assertThat(refund.getStatus()).isEqualTo(RefundStatus.REFUND_REQUESTED);
+		assertThat(refund.getType()).isEqualTo(RefundType.RETURN);
+		assertThat(refund.getReason()).isEqualTo("상품 불량");
+		assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.ORDER_DELIVERED); // Order 상태는 변경되지 않음
+	}
+
+	@Test
+	@DisplayName("환불 승인 성공 - 재고 복원 확인")
+	void 환불_승인_성공_재고복원() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		Long stockBefore = productRepository.findByIdOrThrow(testProduct.getId()).getStock();
+
+		// when
+		orderService.approveRefund(testOrder.getId());
+
+		// then
+		var refund = refundRepository.findAll().get(0);
+		assertThat(refund.getStatus()).isEqualTo(RefundStatus.REFUND_COMPLETED);
+
+		var product = productRepository.findByIdOrThrow(testProduct.getId());
+		assertThat(product.getStock()).isEqualTo(stockBefore + 2L); // 재고 복원 확인
+		assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.ORDER_SHIPPING); // Order 상태는 변경되지 않음
+	}
+
+	@Test
+	@DisplayName("반품 승인 성공 - 재고 복원 확인")
+	void 반품_승인_성공_재고복원() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_DELIVERED);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.RETURN, "상품 불량");
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		Long stockBefore = productRepository.findByIdOrThrow(testProduct.getId()).getStock();
+
+		// when
+		orderService.approveRefund(testOrder.getId());
+
+		// then
+		var refund = refundRepository.findAll().get(0);
+		assertThat(refund.getStatus()).isEqualTo(RefundStatus.REFUND_COMPLETED);
+
+		var product = productRepository.findByIdOrThrow(testProduct.getId());
+		assertThat(product.getStock()).isEqualTo(stockBefore + 2L); // 재고 복원 확인
+	}
+
+	@Test
+	@DisplayName("환불 거절 성공")
+	void 환불_거절_성공() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		var refund = refundRepository.findAll().get(0);
+		var rejectRequest = new RefundRejectRequest("환불 기한 초과");
+
+		// when
+		orderService.rejectRefund(refund.getId(), rejectRequest);
+
+		// then
+		var rejectedRefund = refundRepository.findByIdOrThrow(refund.getId());
+		assertThat(rejectedRefund.getStatus()).isEqualTo(RefundStatus.REFUND_REJECTED);
+		assertThat(rejectedRefund.getRejectionReason()).isEqualTo("환불 기한 초과");
+		assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.ORDER_SHIPPING); // Order 상태는 변경되지 않음
+	}
+
+	@Test
+	@DisplayName("중복 환불 요청 실패")
+	void 중복_환불_요청_실패() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+
+		// 첫 번째 환불 요청 및 승인
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+		orderService.approveRefund(testOrder.getId());
+
+		// when & then - 두 번째 환불 요청 시 예외 발생
+		assertThatThrownBy(() ->
+			orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest)
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.ALREADY_REFUNDED.getMessage());
+	}
+
+	@Test
+	@DisplayName("환불 불가능한 상태에서 요청 실패 - ORDER_CREATED")
+	void 환불_불가능한_상태_요청_실패() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_CREATED);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+
+		// when & then
+		assertThatThrownBy(() ->
+			orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest)
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+	}
+
+	@Test
+	@DisplayName("권한 없는 사용자의 환불 요청 실패")
+	void 권한_없는_사용자_환불_요청_실패() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder);
+		var otherUser = userRepository.save(
+			new User(
+				"otheruser",
+				"password",
+				"Other User",
+				"other@email.com",
+				"010-9999-9999",
+				Gender.FEMALE,
+				LocalDate.now(),
+				LocalDateTime.now(),
+				LocalDateTime.now(),
+				Role.CUSTOMER
+			)
+		);
+		var currentUser = new DefaultCurrentUser(otherUser.getId(), otherUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+
+		// when & then
+		assertThatThrownBy(() ->
+			orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest)
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.NO_AUTHORITY_TO_REFUND.getMessage());
+	}
+
+	@Test
+	@DisplayName("환불 요청 상태가 아닌데 승인 시도 시 실패")
+	void 환불_승인_실패_잘못된_상태() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		var refund = refundRepository.findAll().get(0);
+		var rejectRequest = new RefundRejectRequest("환불 기한 초과");
+		orderService.rejectRefund(refund.getId(), rejectRequest); // 먼저 거절
+
+		// when & then - 거절된 환불을 승인하려고 시도
+		assertThatThrownBy(() ->
+			orderService.approveRefund(testOrder.getId())
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.NOT_FOUND_REFUND.getMessage());
+	}
+
+	@Test
+	@DisplayName("환불 요청 상태가 아닌데 거절 시도 시 실패")
+	void 환불_거절_실패_잘못된_상태() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder);
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		var refund = refundRepository.findAll().get(0);
+		orderService.approveRefund(testOrder.getId()); // 먼저 승인
+
+		var rejectRequest = new RefundRejectRequest("환불 기한 초과");
+
+		// when & then - 승인된 환불을 거절하려고 시도
+		assertThatThrownBy(() ->
+			orderService.rejectRefund(refund.getId(), rejectRequest)
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INVALID_REFUND_STATUS.getMessage());
+	}
+
+	@Test
+	@DisplayName("환불 요청 후 Order 상태는 변경되지 않음")
+	void 환불_요청_후_Order_상태_불변() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_SHIPPING);
+		orderRepository.saveAndFlush(testOrder);
+		var originalStatus = testOrder.getStatus();
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.REFUND, "단순 변심");
+
+		// when
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		// then
+		var order = orderRepository.findByOrderIdOrThrow(testOrder.getId(), ErrorCode.NOT_FOUND_ORDER);
+		assertThat(order.getStatus()).isEqualTo(originalStatus);
+	}
+
+	@Test
+	@DisplayName("환불 거절 후 Order 상태는 변경되지 않음")
+	void 환불_거절_후_Order_상태_불변() {
+		// given
+		testOrder.changeStatus(OrderStatus.ORDER_DELIVERED);
+		orderRepository.saveAndFlush(testOrder);
+		var originalStatus = testOrder.getStatus();
+		var currentUser = new DefaultCurrentUser(testUser.getId(), testUser.getLoginId());
+		var refundRequest = new RefundRequest(RefundType.RETURN, "상품 불량");
+		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
+
+		var refund = refundRepository.findAll().get(0);
+		var rejectRequest = new RefundRejectRequest("반품 기한 초과");
+
+		// when
+		orderService.rejectRefund(refund.getId(), rejectRequest);
+
+		// then
+		var order = orderRepository.findByOrderIdOrThrow(testOrder.getId(), ErrorCode.NOT_FOUND_ORDER);
+		assertThat(order.getStatus()).isEqualTo(originalStatus);
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,6 +13,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         show_sql: false
     show-sql: false
+    open-in-view: false
   data:
     redis:
       cluster:


### PR DESCRIPTION
##🔧 구현 내용
환불 및 반품 도메인 로직의 안정성을 보장하기 위해 OrderService에 포함된 관련 기능에 대한 통합 테스트 코드를 작성했습니다.

- `RefundServiceTest` 통합 테스트 코드 작성
- 성공 시나리오
  - 배송중/배송완료 상태에 따른 환불/반품 요청
  - 환불/반품 승인 시 재고 복원 기능
  - 환불/반품 거절 기능
- 실패 시나리오 (예외 처리)
  - 이미 처리된 주문에 대한 중복 환불/반품 요청
  - 환불/반품이 불가능한 주문 상태에서의 요청
  - 다른 사용자의 주문에 대한 환불/반품 요청
  - 부적절한 상태(ex. 거절된 건)에 대한 승인 시도
- 도메인 독립성 검증
  - 환불/반품 절차 진행 중 Order의 상태가 변경되지 않음을 확인

 - 테스트 문제 해결
  - JPA 영속성 문제: 테스트 내 엔티티 상태 변경이 DB에 즉시 반영되지 않는 문제를 saveAndFlush()를 사용하여 해결했습니다.
  - 재고 복원 검증 오류: 부정확한 재고 수량 비교 문제를 해결하기 위해, 메모리가 아닌 DB에서 직접 재고를 조회하여 검증하도록 수정했습니다.

## 📌 관련 Jira Issue
   - KAN-95

### 🧪 테스트 방법
- 체크 포인트
  - ✅ 모든 테스트 케이스 통과 (총 12개)
  - ✅ 배송 상태에 따른 환불/반품 요청 및 상태 검증
  - ✅ 환불/반품 승인 시 재고 복원 로직 검증
  - ✅ 중복 환불/반품 요청 방지 로직 검증
  - ✅ 사용자 권한 및 주문 상태에 따른 예외 처리 검증
  - ✅ 환불/반품 처리 과정에서 주문 상태의 불변성 확인

### ❗ 기타 참고 사항
   - @Transactional 어노테이션을 통해 각 테스트 종료 후 데이터가 자동으로 롤백됩니다.
   - H2 인메모리 데이터베이스를 사용하여 독립적인 테스트 환경을 보장합니다.