### PR TITLE
refactor(order): 리포지토리 메서드에 에러코드 고정

### DIFF
--- a/src/main/java/com/kt/repository/order/OrderRepository.java
+++ b/src/main/java/com/kt/repository/order/OrderRepository.java
@@ -34,13 +34,13 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
 	@EntityGraph(attributePaths = {"orderProducts", "orderProducts.product", "user"})
 	Optional<Order> findByIdAndUserId(Long id, Long userId);
 
-    default Order findByIdAndUserIdOrThrow(Long id, Long userId, ErrorCode errorCode) {
+    default Order findByIdAndUserIdOrThrow(Long id, Long userId) {
         return findByIdAndUserId(id, userId)
-            .orElseThrow(() -> new CustomException(errorCode));
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ORDER));
     }
 
-	default Order findByOrderIdOrThrow(Long id, ErrorCode errorCode) {
-		return findById(id)
-			.orElseThrow(() -> new CustomException(errorCode));
-	}
+    default Order findByOrderIdOrThrow(Long id) {
+        return findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ORDER));
+    }
 }

--- a/src/main/java/com/kt/repository/order/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/order/OrderRepositoryCustomImpl.java
@@ -28,7 +28,6 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
-	// QClass를 임포트해서 쿼리를 작성할 때 사용하면 됩니다.
 	private final JPAQueryFactory jpaQueryFactory;
 	private final QOrder order = QOrder.order;
 	private final QOrderProduct orderProduct = QOrderProduct.orderProduct;
@@ -40,21 +39,11 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 			String keyword,
 			Pageable pageable
 	) {
-		// 페이징을 구현할때
-		// offset, limit
-		// select *
-		// booleanBuilder, BooleanExpression
 		var booleanBuilder = new BooleanBuilder();
 
 		booleanBuilder.and(containsProductName(keyword));
 
-		// booleanBuilder.and()
-		// booleanBuilder.or()
-		// booleanBuilder안에다가 booleanExpression을 추가해주는 방식으로
-
 		var content = jpaQueryFactory
-				// order자리에 QOrderResponse_Search
-				// totalPrice는 product의 price * orderProduct.quantity
 				.select(new QOrderResponse_Search(
 						order.id,
 						order.receiver.name,
@@ -74,9 +63,6 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.fetch();
-		// 최초에 페이지 접근했을때 -> 전체검색이 되야할까 아니면 특정키워드검색이 자동으로 되야하나
-		// name like '%null%' (동작 해야하나?) - 동작안해야
-		// keyword = null
 
 		var total = (long)jpaQueryFactory.select(order.id)
 				.from(order)
@@ -115,19 +101,7 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 	}
 
-	// 시작하는 '%keyword'
-	// 끝나는 'keyword%'
-	// 포함하는 '%" "%'
-	// 공백이면 어쩌징
-
-	// Strings
-	// Objects
 	private BooleanExpression containsProductName(String keyword) {
-		// if(Strings.isNotBlank(keyword)) {
-		// 	return product.name.containsIgnoreCase(keyword);
-		// } else {
-		// 	return null;
-		// }
 		return Strings.isNotBlank(keyword) ? product.name.containsIgnoreCase(keyword) : null;
 	}
 

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -89,7 +89,7 @@ public class OrderService {
 	}
 
 	public void requestCancelByUser(Long orderId, CurrentUser currentUser, String reason) {
-		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		Order order = orderRepository.findByOrderIdOrThrow(orderId);
 		// '주문'에 기록된 사용자 ID와 '현재 요청한' 사용자 ID를 바로 비교
 		Preconditions.validate(
 				order.getUser()
@@ -99,7 +99,7 @@ public class OrderService {
 	}
 
 	public void requestRefundByUser(Long orderId, CurrentUser currentUser, RefundRequest request) {
-		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		Order order = orderRepository.findByOrderIdOrThrow(orderId);
 		Preconditions.validate(
 				order.getUser().getId().equals(currentUser.getId()),
 				ErrorCode.NO_AUTHORITY_TO_REFUND
@@ -120,7 +120,7 @@ public class OrderService {
 	// 현재는 즉시 취소 처리로 변경되어 이 메서드는 사용되지 않음
 	@Deprecated
 	public void decideCancel(Long orderId, OrderCancelDecisionRequest request) {
-		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		Order order = orderRepository.findByOrderIdOrThrow(orderId);
 		// 즉시 취소로 변경되어 승인 프로세스 제거됨
 		throw new UnsupportedOperationException("취소는 즉시 처리됩니다. requestCancelByUser를 사용하세요.");
 	}
@@ -139,7 +139,7 @@ public class OrderService {
 
 
 	public void approveRefund(Long orderId) {
-		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		Order order = orderRepository.findByOrderIdOrThrow(orderId);
 		Refund refund = refundRepository.findRefundRequestByOrderOrThrow(order);
 
 		// Refund 도메인에서 독립적으로 상태 관리
@@ -197,7 +197,7 @@ public class OrderService {
 
 	@Transactional(readOnly = true)
 	public OrderResponse.AdminDetail getAdminOrderDetail(Long orderId) {
-		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		Order order = orderRepository.findByOrderIdOrThrow(orderId);
 
 		List<OrderResponse.Item> items = order.getOrderProducts().stream()
 				.map(op -> new OrderResponse.Item(
@@ -224,7 +224,7 @@ public class OrderService {
 	}
 
 	public void changeOrderStatus(Long orderId, OrderStatusUpdateRequest request) {
-		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		Order order = orderRepository.findByOrderIdOrThrow(orderId);
 		order.changeStatus(request.status());
 	}
 }

--- a/src/main/java/com/kt/service/PaymentService.java
+++ b/src/main/java/com/kt/service/PaymentService.java
@@ -23,7 +23,7 @@ public class PaymentService {
 
 	public void pay(Long orderId, PaymentType paymentType) {
 		// 주문 정보 가져오기
-		Order order = orderRepository.findByOrderIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+		Order order = orderRepository.findByOrderIdOrThrow(orderId);
 
 		// 주문 상태 확인하기(이미 결제 되었는지)
 		Preconditions.validate(order.getStatus() == OrderStatus.ORDER_CREATED, ErrorCode.ALREADY_PAID_ORDER);

--- a/src/main/java/com/kt/service/UserOrderService.java
+++ b/src/main/java/com/kt/service/UserOrderService.java
@@ -23,7 +23,7 @@ public class UserOrderService {
 	// 주문 상세 조회
 	@Transactional(readOnly = true)
 	public OrderResponse.Detail getByIdForUser(Long userId, Long orderId) {
-		var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
+		var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId);
 		return mapToDetail(order);
 	}
 
@@ -36,7 +36,7 @@ public class UserOrderService {
 
     @Transactional
     public void updateOrder(Long userId, Long orderId, OrderRequest.Update request) {
-        var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
+        var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId);
 
         Preconditions.validate(order.canUpdate(), ErrorCode.CANNOT_UPDATE_ORDER);
         order.changeReceiver(

--- a/src/test/java/com/kt/service/RefundServiceTest.java
+++ b/src/test/java/com/kt/service/RefundServiceTest.java
@@ -310,7 +310,7 @@ class RefundServiceTest {
 		orderService.requestRefundByUser(testOrder.getId(), currentUser, refundRequest);
 
 		// then
-		var order = orderRepository.findByOrderIdOrThrow(testOrder.getId(), ErrorCode.NOT_FOUND_ORDER);
+		var order = orderRepository.findByOrderIdOrThrow(testOrder.getId());
 		assertThat(order.getStatus()).isEqualTo(originalStatus);
 	}
 
@@ -332,7 +332,7 @@ class RefundServiceTest {
 		orderService.rejectRefund(refund.getId(), rejectRequest);
 
 		// then
-		var order = orderRepository.findByOrderIdOrThrow(testOrder.getId(), ErrorCode.NOT_FOUND_ORDER);
+		var order = orderRepository.findByOrderIdOrThrow(testOrder.getId());
 		assertThat(order.getStatus()).isEqualTo(originalStatus);
 	}
 }

--- a/src/test/java/com/kt/service/UserOrderServiceTest.java
+++ b/src/test/java/com/kt/service/UserOrderServiceTest.java
@@ -55,7 +55,7 @@ class UserOrderServiceTest {
         createOrderProduct(order, product2, 1L);
         long expectedTotalPrice = 1_000L * 2 + 2_000L * 1;
 
-        given(orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER))
+        given(orderRepository.findByIdAndUserIdOrThrow(orderId, userId))
             .willReturn(order);
 
         // when
@@ -74,7 +74,7 @@ class UserOrderServiceTest {
         assertThat(detail.createdAt()).isEqualTo(order.getCreatedAt());
 
         then(orderRepository).should()
-            .findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
+            .findByIdAndUserIdOrThrow(orderId, userId);
     }
 
     @Test
@@ -139,7 +139,7 @@ class UserOrderServiceTest {
         Receiver receiver = createReceiver("홍길동", "서울시 1", "010-0000-0000");
         Order order = createOrder(receiver, user, OrderStatus.ORDER_CREATED); // canUpdate() = true
 
-        given(orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER))
+        given(orderRepository.findByIdAndUserIdOrThrow(orderId, userId))
             .willReturn(order);
 
         OrderRequest.Update request = new OrderRequest.Update(
@@ -153,7 +153,7 @@ class UserOrderServiceTest {
 
         // then
         then(orderRepository).should()
-            .findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
+            .findByIdAndUserIdOrThrow(orderId, userId);
 
         assertThat(order.getReceiver().getName()).isEqualTo(request.receiverName());
         assertThat(order.getReceiver().getAddress()).isEqualTo(request.receiverAddress());
@@ -175,7 +175,7 @@ class UserOrderServiceTest {
         String originalAddress = order.getReceiver().getAddress();
         String originalMobile = order.getReceiver().getMobile();
 
-        given(orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER))
+        given(orderRepository.findByIdAndUserIdOrThrow(orderId, userId))
             .willReturn(order);
 
         OrderRequest.Update request = new OrderRequest.Update(
@@ -196,7 +196,7 @@ class UserOrderServiceTest {
         assertThat(order.getReceiver().getMobile()).isEqualTo(originalMobile);
 
         then(orderRepository).should()
-            .findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
+            .findByIdAndUserIdOrThrow(orderId, userId);
     }
 
     // 픽스처 메서드


### PR DESCRIPTION
### 🔧 구현 내용
- `OrderRepository`의 `findByIdAndUserIdOrThrow`와 `findByOrderIdOrThrow`의 에러코드를 `NOT_FOUND_ORDER`로 고정했습니다.
→ 반복되는 예외 처리 로직을 리포지토리에 캡슐화하여 서비스 코드를 간결하게 만듭니다.

### 📌 관련 Jira Issue

- KAN-102

### 🧪 테스트 방법

- UserOrderServiceTest
- RefundServiceTest