### PR TITLE
feat(answer): KAN-37 [Q&A] 상품 문의 답변 기능 구현

### DIFF
--- a/src/main/java/com/kt/domain/question/Answer.java
+++ b/src/main/java/com/kt/domain/question/Answer.java
@@ -1,0 +1,57 @@
+package com.kt.domain.question;
+
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.BaseEntity;
+import com.kt.common.support.Preconditions;
+import com.kt.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Answer extends BaseEntity {
+
+	@Lob
+	@Column(nullable = false)
+	private String content;
+
+	@ManyToOne
+	@JoinColumn(name = "admin_id", nullable = false)
+	private User admin;
+
+	@OneToOne
+	@JoinColumn(name = "question_id", nullable = false)
+	private Question question;
+
+	public Answer(String content, User admin, Question question) {
+		Preconditions.validate(content != null && !content.isBlank(), ErrorCode.INVALID_PARAMETER);
+		Preconditions.validate(admin != null, ErrorCode.INVALID_PARAMETER);
+		Preconditions.validate(question != null, ErrorCode.INVALID_PARAMETER);
+
+		this.content = content;
+		this.admin = admin;
+		this.question = question;
+
+		// 양방향 관계 설정: Question의 상태를 답변 완료로 변경
+		question.markAsAnswered();
+	}
+
+	// 답변 내용 수정
+	public void updateContent(String content) {
+		Preconditions.validate(content != null && !content.isBlank(), ErrorCode.INVALID_PARAMETER);
+		this.content = content;
+	}
+
+	// 작성자 확인 (관리자)
+	public boolean isWrittenBy(Long adminId) {
+		return this.admin.getId().equals(adminId);
+	}
+}

--- a/src/main/java/com/kt/dto/question/AnswerRequest.java
+++ b/src/main/java/com/kt/dto/question/AnswerRequest.java
@@ -1,0 +1,20 @@
+package com.kt.dto.question;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class AnswerRequest {
+
+	public record Create(
+		@NotNull(message = "문의 ID는 필수입니다.")
+		Long questionId,
+
+		@NotBlank(message = "답변 내용은 필수입니다.")
+		String content
+	) {}
+
+	public record Update(
+		@NotBlank(message = "답변 내용은 필수입니다.")
+		String content
+	) {}
+}

--- a/src/main/java/com/kt/dto/question/AnswerResponse.java
+++ b/src/main/java/com/kt/dto/question/AnswerResponse.java
@@ -1,0 +1,23 @@
+package com.kt.dto.question;
+
+import java.time.LocalDateTime;
+
+import com.kt.domain.question.Answer;
+
+public record AnswerResponse(
+	Long id,
+	String content,
+	String adminName,
+	Long questionId,
+	LocalDateTime createdAt
+) {
+	public static AnswerResponse from(Answer answer) {
+		return new AnswerResponse(
+			answer.getId(),
+			answer.getContent(),
+			answer.getAdmin().getName(),
+			answer.getQuestion().getId(),
+			answer.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kt/repository/question/AnswerRepository.java
+++ b/src/main/java/com/kt/repository/question/AnswerRepository.java
@@ -1,0 +1,22 @@
+package com.kt.repository.question;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
+import com.kt.domain.question.Answer;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+	default Answer findByIdOrThrow(Long id) {
+		return findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ANSWER));
+	}
+
+	/**
+	 * 특정 문의의 답변 조회
+	 */
+	Optional<Answer> findByQuestionId(Long questionId);
+}

--- a/src/main/java/com/kt/service/AnswerService.java
+++ b/src/main/java/com/kt/service/AnswerService.java
@@ -1,0 +1,77 @@
+package com.kt.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.Preconditions;
+import com.kt.domain.question.Answer;
+import com.kt.domain.question.Question;
+import com.kt.domain.user.User;
+import com.kt.dto.question.AnswerRequest;
+import com.kt.dto.question.AnswerResponse;
+import com.kt.repository.question.AnswerRepository;
+import com.kt.repository.question.QuestionRepository;
+import com.kt.repository.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AnswerService {
+
+	private final AnswerRepository answerRepository;
+	private final QuestionRepository questionRepository;
+	private final UserRepository userRepository;
+
+	// 답변 작성 (관리자)
+	public void createAnswer(Long adminId, AnswerRequest.Create request) {
+		User admin = userRepository.findByIdOrThrow(adminId);
+		Question question = questionRepository.findByIdOrThrow(request.questionId());
+
+		// 이미 답변이 있는지 확인
+		Preconditions.validate(question.getAnswer() == null, ErrorCode.ALREADY_ANSWERED);
+
+		Answer answer = new Answer(
+				request.content(),
+				admin,
+				question
+		);
+
+		answerRepository.save(answer);
+	}
+
+	// 답변 조회 (문의 ID로)
+	@Transactional(readOnly = true)
+	public AnswerResponse getAnswerByQuestionId(Long questionId) {
+		questionRepository.findByIdOrThrow(questionId); // 문의 존재 확인
+
+		return answerRepository.findByQuestionId(questionId)
+				.map(AnswerResponse::from)
+				.orElse(null);
+	}
+
+	// 답변 수정 (관리자)
+	public void updateAnswer(Long answerId, Long adminId, AnswerRequest.Update request) {
+		Answer answer = findAnswerByIdAndValidateWriter(answerId, adminId, ErrorCode.NO_AUTHORITY_TO_UPDATE_ANSWER);
+		answer.updateContent(request.content());
+	}
+
+	// 답변 삭제 (관리자)
+	public void deleteAnswer(Long answerId, Long adminId) {
+		Answer answer = findAnswerByIdAndValidateWriter(answerId, adminId, ErrorCode.NO_AUTHORITY_TO_DELETE_ANSWER);
+
+		// Question의 상태를 다시 PENDING으로 변경
+		answer.getQuestion().markAsPending();
+
+		answerRepository.delete(answer);
+	}
+
+	// 답변 조회 및 작성자 검증 (헬퍼 메서드)
+	private Answer findAnswerByIdAndValidateWriter(Long answerId, Long adminId, ErrorCode errorCode) {
+		Answer answer = answerRepository.findByIdOrThrow(answerId);
+		Preconditions.validate(answer.isWrittenBy(adminId), errorCode);
+		return answer;
+	}
+}


### PR DESCRIPTION
## 🔧 구현 내용
**상품 문의 답변 도메인 구현**
- Answer 엔티티 생성 및 도메인 로직 구현
  - 작성자 확인 (isWrittenBy)
  - 답변 내용 검증 및 수정 로직
- AnswerRepository 구현 (문의 ID로 답변 조회)
- Question과 Answer의 양방향 연관관계 설정 (OneToOne)

**관리자 답변 관리 API (AdminQuestionController)**
- 답변 작성: 문의에 대한 답변 등록, 중복 답변 방지
- 답변 수정: 답변 작성자만 수정 가능
- 답변 삭제: 답변 작성자만 삭제 가능

**도메인 간 상태 동기화**
- 답변 작성 시 Question 상태 자동 변경 (PENDING → ANSWERED)
- 답변 삭제 시 Question 상태 자동 복원 (ANSWERED → PENDING)
- 양방향 관계 정합성 유지

**기술 구현**
- AnswerRequest/AnswerResponse DTO를 Java record로 구현
- static factory method 패턴 적용 (AnswerResponse.from())
- ErrorCode에 Answer 관련 에러 코드 추가 (NOT_FOUND_ANSWER, NO_AUTHORITY 등)

### 📌 관련 Jira Issue
- KAN-37

## 🧪 테스트 방법
**관리자 답변 API**
- `POST /admin/questions/answers` - 답변 작성
  - Body: `{"questionId": 1, "content": "재고는 100개 남았습니다."}`
  - 체크: 답변 생성 성공, Question 상태가 ANSWERED로 변경
  - 체크: 중복 답변 시도 시 400 에러 (ALREADY_ANSWERED)

- `PUT /admin/questions/answers/{answerId}` - 답변 수정
  - Body: `{"content": "수정된 답변 내용"}`
  - 체크: 답변 작성자만 수정 가능, 다른 관리자 시도 시 403 에러

- `DELETE /admin/questions/answers/{answerId}` - 답변 삭제
  - 체크: 답변 삭제 성공, Question 상태가 PENDING으로 복원
  - 체크: 답변 작성자만 삭제 가능

**상태 동기화 확인**
- 답변 작성 후 `GET /questions/{questionId}` 호출
  - 체크: `status: "ANSWERED"`, `hasAnswer: true`, `answer` 객체 포함
- 답변 삭제 후 `GET /questions/{questionId}` 호출
  - 체크: `status: "PENDING"`, `hasAnswer: false`, `answer: null`

### ❗ 기타 참고 사항
- Question PR(#104)과 의존 관계: Question 엔티티가 Answer를 참조하므로 Question PR이 먼저 머지되어야 함
- 모든 DTO를 Java record로 구현하여 코드 간결성 향상
- 답변은 관리자만 작성/수정/삭제 가능 (`@PreAuthorize("hasRole('ADMIN')")`)
- 답변 작성자 검증으로 다른 관리자의 답변 수정/삭제 방지