### PR TITLE
hotfix(test): 컨트롤러 테스트 실패 원인인 JwtFilter mock 제거

### DIFF
--- a/src/test/java/com/kt/controller/payment/PaymentControllerTest.java
+++ b/src/test/java/com/kt/controller/payment/PaymentControllerTest.java
@@ -21,7 +21,6 @@ import com.kt.domain.payment.PaymentType;
 import com.kt.dto.payment.PaymentRequest;
 import com.kt.repository.payment.PaymentTypeRepository;
 import com.kt.repository.user.UserRepository;
-import com.kt.security.JwtFilter;
 import com.kt.security.JwtService;
 import com.kt.security.WithMockCustomUser;
 import com.kt.service.PaymentService;
@@ -45,9 +44,6 @@ class PaymentControllerTest {
 
 	@MockitoBean
 	private JwtService jwtService;
-
-	@MockitoBean
-	private JwtFilter jwtFilter;
 
 	@MockitoBean
 	private UserRepository userRepository;

--- a/src/test/java/com/kt/controller/product/AdminProductControllerTest.java
+++ b/src/test/java/com/kt/controller/product/AdminProductControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -30,7 +29,6 @@ import com.kt.domain.product.ProductStatus;
 import com.kt.domain.user.Role;
 import com.kt.dto.product.ProductRequest;
 import com.kt.repository.user.UserRepository;
-import com.kt.security.JwtFilter;
 import com.kt.security.JwtService;
 import com.kt.security.WithMockCustomUser;
 import com.kt.service.ProductService;
@@ -49,8 +47,6 @@ class AdminProductControllerTest {
 	private RedisService redisService;
 	@MockitoBean
 	private JwtService jwtService;
-	@MockitoBean
-	private JwtFilter jwtFilter;
 	@MockitoBean
 	private UserRepository userRepository;
 	@Autowired

--- a/src/test/java/com/kt/controller/question/AdminQuestionControllerTest.java
+++ b/src/test/java/com/kt/controller/question/AdminQuestionControllerTest.java
@@ -30,7 +30,6 @@ import com.kt.domain.user.User;
 import com.kt.dto.question.AnswerRequest;
 import com.kt.dto.question.QuestionResponse;
 import com.kt.repository.user.UserRepository;
-import com.kt.security.JwtFilter;
 import com.kt.security.JwtService;
 import com.kt.security.WithMockCustomUser;
 import com.kt.service.AnswerService;
@@ -61,9 +60,6 @@ class AdminQuestionControllerTest {
 	private JwtService jwtService;
 
 	@MockitoBean
-	private JwtFilter jwtFilter;
-
-	@MockitoBean
 	private UserRepository userRepository;
 
 	private Question testQuestion;
@@ -86,15 +82,14 @@ class AdminQuestionControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/admin/questions")
-			.param("page", "0")
-			.param("size", "10")
-			.contentType(MediaType.APPLICATION_JSON))
-			.andDo(result -> System.out.println("Response: " + result.getResponse().getContentAsString()));
+						.param("page", "0")
+						.param("size", "10")
+						.contentType(MediaType.APPLICATION_JSON));
 
 		// then
 		resultActions.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.content[0].content").value(testQuestion.getContent()))
-			.andExpect(jsonPath("$.data.content.length()").value(1));
+				.andExpect(jsonPath("$.data.content[0].content").value(testQuestion.getContent()))
+				.andExpect(jsonPath("$.data.content.length()").value(1));
 		verify(questionService, times(1)).getAdminQuestions(any(Pageable.class));
 	}
 
@@ -108,11 +103,11 @@ class AdminQuestionControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(delete("/admin/questions/{questionId}", questionId)
-			.contentType(MediaType.APPLICATION_JSON));
+				.contentType(MediaType.APPLICATION_JSON));
 
 		// then
 		resultActions.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("ok"));
+				.andExpect(jsonPath("$.code").value("ok"));
 		verify(questionService, times(1)).deleteQuestionByAdmin(anyLong());
 	}
 
@@ -126,12 +121,12 @@ class AdminQuestionControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/admin/questions/answers")
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(request)));
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
 
 		// then
 		resultActions.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("ok"));
+				.andExpect(jsonPath("$.code").value("ok"));
 		verify(answerService, times(1)).createAnswer(anyLong(), any(AnswerRequest.Create.class));
 	}
 
@@ -146,12 +141,12 @@ class AdminQuestionControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(put("/admin/questions/answers/{answerId}", answerId)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(request)));
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
 
 		// then
 		resultActions.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("ok"));
+				.andExpect(jsonPath("$.code").value("ok"));
 		verify(answerService, times(1)).updateAnswer(anyLong(), anyLong(), any(AnswerRequest.Update.class));
 	}
 
@@ -165,11 +160,11 @@ class AdminQuestionControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(delete("/admin/questions/answers/{answerId}", answerId)
-			.contentType(MediaType.APPLICATION_JSON));
+				.contentType(MediaType.APPLICATION_JSON));
 
 		// then
 		resultActions.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("ok"));
+				.andExpect(jsonPath("$.code").value("ok"));
 		verify(answerService, times(1)).deleteAnswer(anyLong(), anyLong());
 	}
 }


### PR DESCRIPTION
### 🔧 구현 내용

- **무엇을**: AdminProductControllerTest, AdminQuestionControllerTest, PaymentControllerTest에서 
```java
@MockitoBean private 
    JwtFilter jwtFilter;
```
제거
- **왜**: Mock JwtFilter가 `filterChain.doFilter()`를 호출하지 않아 HTTP 요청이 컨트롤러에 도달하지 못해 전체 테스트 실패 (Handler: Type = null, 빈 응답 body)
- **어떻게**: 잘못된 코드 리뷰 제안으로 추가된 JwtFilter mock 선언 삭제. `@WithMockCustomUser`가 이미 SecurityContext 설정을 처리하므로 별도 필터 mock 불필요

### 🧪 테스트 방법
- `./gradlew test --tests AdminProductControllerTest` 실행
- `./gradlew test --tests AdminQuestionControllerTest` 실행
 - `./gradlew test --tests PaymentControllerTest` 실행
- 체크 포인트: 테스트 전부 PASSED 확인

### ❗ 기타 참고 사항
  - GPT Codex 코드 리뷰에서 "JwtFilter 빈이 없어서 실패할 것"이라는 잘못된 제안을 반영했다가 발생한 문제
  - `@Import(SecurityConfiguration.class)` + `@WithMockCustomUser` 조합에서는 JwtFilter mock이 오히려 방해됨
  - Slice test에서는 필터 mock 없이 인증만 모킹하는 것이 올바른 패턴

### 1. @WebMvcTest는 slice test: 컨트롤러 레이어만 로드하고, @Component인 JwtFilter는 자동 스캔 안 함

### 2. 하지만 @Import(SecurityConfiguration.class) 자체가 문제:
    - SecurityConfiguration을 Import하면 실제 Security Filter Chain이 구성됨
    - Filter Chain에 jwtFilter가 등록되면서 실제로 필터가 실행되려고 시도함
    - @MockitoBean으로 만든 mock JwtFilter는 아무 동작도 하지 않는 빈 껍데기
    - 필터 체인이 제대로 작동하지 않아서 요청이 컨트롤러까지 도달하지 못함
    - 그래서 Handler: Type = null, 빈 응답 발생

### 3. ProductControllerTest는 왜 잘 돌아가는가?
    - @Import(SecurityConfiguration.class) 없음
    - @WithMockCustomUser가 SecurityContext만 설정해주면 됨

### 결론:
    - @WithMockCustomUser가 이미 인증을 모킹해주고 있어서 SecurityConfiguration 필요 없음
    - Slice test에서 실제 Security Configuration 로드하는 건 안티패턴임