### PR TITLE
feat(review): KAN-129 상품 리뷰 AI 요약 조회 API 구현

### DIFF
--- a/src/main/java/com/kt/config/SecurityConfiguration.java
+++ b/src/main/java/com/kt/config/SecurityConfiguration.java
@@ -26,7 +26,8 @@ public class SecurityConfiguration {
     private static final String[] GET_PERMIT_ALL = {
             "/api/health/**",
             "/swagger-ui/**",
-            "/v3/api-docs/**"
+            "/v3/api-docs/**",
+            "/api/reviews/summary"
     };
 
     private static final String[] POST_PERMIT_ALL = {

--- a/src/main/java/com/kt/controller/reviewsummary/ReviewSummaryController.java
+++ b/src/main/java/com/kt/controller/reviewsummary/ReviewSummaryController.java
@@ -1,0 +1,38 @@
+package com.kt.controller.reviewsummary;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.common.response.ApiResult;
+import com.kt.dto.reviewsummary.ReviewSummaryResponse;
+import com.kt.service.ReviewSummaryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Review Summary", description = "상품 리뷰 요약 API")
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewSummaryController {
+
+    private final ReviewSummaryService reviewSummaryService;
+
+    @Operation(
+        summary = "상품 리뷰 요약 조회",
+        description = "상품의 최근 리뷰를 기반으로 AI 요약을 반환합니다. 캐시가 유효하면 캐시를 반환하고, 필요 시 재생성합니다."
+    )
+    @Parameters({
+        @Parameter(name = "productId", description = "상품 ID", required = true, example = "1")
+    })
+    @GetMapping("/summary")
+    public ApiResult<ReviewSummaryResponse> getSummary(@RequestParam Long productId) {
+        var response = reviewSummaryService.getOrGenerate(productId);
+        return ApiResult.ok(response);
+    }
+}

--- a/src/main/java/com/kt/domain/reviewsummary/ReviewSummary.java
+++ b/src/main/java/com/kt/domain/reviewsummary/ReviewSummary.java
@@ -1,0 +1,87 @@
+package com.kt.domain.reviewsummary;
+
+import com.kt.common.support.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(
+    name = "review_summaries",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_review_summaries_product_id", columnNames = "product_id")
+    }
+)
+@NoArgsConstructor
+public class ReviewSummary extends BaseEntity {
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(nullable = false)
+    private int reviewCountUsed;
+
+    private Long lastReviewIdUsed;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String summary;
+
+    @Convert(converter = StringListJsonConverter.class)
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private List<String> pros;
+
+    @Convert(converter = StringListJsonConverter.class)
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private List<String> cons;
+
+    @Convert(converter = StringListJsonConverter.class)
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private List<String> keywords;
+
+    @Column(nullable = false)
+    private String model;
+
+    @Column(nullable = false)
+    private String promptVersion;
+
+    @Column(nullable = false)
+    private LocalDateTime generatedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    public boolean isValid(LocalDateTime now) {
+        return expiresAt.isAfter(now);
+    }
+
+    public static ReviewSummary of(
+        Long productId,
+        int reviewCountUsed,
+        Long lastReviewIdUsed,
+        String summary,
+        List<String> pros,
+        List<String> cons,
+        List<String> keywords,
+        String model,
+        String promptVersion,
+        LocalDateTime now,
+        LocalDateTime expiresAt
+    ) {
+        var e = new ReviewSummary();
+        e.productId = productId;
+        e.reviewCountUsed = reviewCountUsed;
+        e.lastReviewIdUsed = lastReviewIdUsed;
+        e.summary = summary;
+        e.pros = pros;
+        e.cons = cons;
+        e.keywords = keywords;
+        e.model = model;
+        e.promptVersion = promptVersion;
+        e.generatedAt = now;
+        e.expiresAt = expiresAt;
+        return e;
+    }
+}

--- a/src/main/java/com/kt/domain/reviewsummary/StringListJsonConverter.java
+++ b/src/main/java/com/kt/domain/reviewsummary/StringListJsonConverter.java
@@ -1,0 +1,34 @@
+package com.kt.domain.reviewsummary;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class StringListJsonConverter implements AttributeConverter<List<String>, String> {
+    private static final ObjectMapper om = new ObjectMapper();
+    private static final TypeReference<List<String>> LIST = new TypeReference<>() {};
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        try {
+            return om.writeValueAsString(attribute == null ? Collections.emptyList() : attribute);
+        } catch (Exception e) {
+            throw new IllegalStateException("List -> JSON 변환 실패", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            if (dbData == null || dbData.isBlank()) return Collections.emptyList();
+            return om.readValue(dbData, LIST);
+        } catch (Exception e) {
+            throw new IllegalStateException("JSON -> List 변환 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/kt/dto/reviewsummary/ReviewSummaryResponse.java
+++ b/src/main/java/com/kt/dto/reviewsummary/ReviewSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.kt.dto.reviewsummary;
+
+import com.kt.domain.reviewsummary.ReviewSummary;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReviewSummaryResponse(
+    Long productId,
+    LocalDateTime generatedAt,
+    String summary,
+    List<String> pros,
+    List<String> cons,
+    List<String> keywords
+) {
+    public static ReviewSummaryResponse from(ReviewSummary e) {
+        return new ReviewSummaryResponse(
+            e.getProductId(),
+            e.getGeneratedAt(),
+            e.getSummary(),
+            e.getPros(),
+            e.getCons(),
+            e.getKeywords()
+        );
+    }
+}

--- a/src/main/java/com/kt/repository/review/ReviewRepository.java
+++ b/src/main/java/com/kt/repository/review/ReviewRepository.java
@@ -8,6 +8,10 @@ import com.kt.domain.review.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
 
@@ -20,4 +24,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
 	boolean existsByOrderProductId(Long orderProductId);
 
+    @Query("""
+		select r
+		from Review r
+		where r.product.id = :productId
+		  and r.isBlinded = false
+		  and r.content is not null
+		  and length(trim(r.content)) > 0
+		order by r.id desc
+	""")
+    List<Review> findRecentForSummary(@Param("productId") Long productId, Pageable pageable);
 }

--- a/src/main/java/com/kt/repository/reviewsummary/ReviewSummaryRepository.java
+++ b/src/main/java/com/kt/repository/reviewsummary/ReviewSummaryRepository.java
@@ -1,0 +1,10 @@
+package com.kt.repository.reviewsummary;
+
+import com.kt.domain.reviewsummary.ReviewSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReviewSummaryRepository extends JpaRepository<ReviewSummary, Long> {
+    Optional<ReviewSummary> findByProductId(Long productId);
+}

--- a/src/main/java/com/kt/service/ChatbotService.java
+++ b/src/main/java/com/kt/service/ChatbotService.java
@@ -119,4 +119,4 @@ public class ChatbotService {
 				""";
 		}
 	}
-			}
+}

--- a/src/main/java/com/kt/service/OpenAiReviewSummaryGenerator.java
+++ b/src/main/java/com/kt/service/OpenAiReviewSummaryGenerator.java
@@ -1,0 +1,118 @@
+package com.kt.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kt.domain.review.Review;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * OpenAI(ChatClient)를 호출해 리뷰 요약 생성
+ */
+@Slf4j
+@Component
+public class OpenAiReviewSummaryGenerator implements ReviewSummaryGenerator {
+    private final ChatClient chatClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${spring.ai.openai.chat.options.model:gpt-4o-mini}")
+    private String model;
+
+    @Value("${openai.prompt-version:v1}")
+    private String promptVersion;
+
+    public OpenAiReviewSummaryGenerator(ChatClient chatClient, ObjectMapper objectMapper) {
+        this.chatClient = chatClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Result generate(List<Review> reviews, double avgRating, Map<Integer, Long> ratingCounts) {
+
+        String dist = ratingCounts.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(e -> e.getKey() + "점:" + e.getValue())
+            .collect(Collectors.joining(", "));
+
+        String reviewLines = reviews.stream()
+            .map(r -> "- (" + r.getRating() + "점) " + trimTo(r.getContent(), 200))
+            .collect(Collectors.joining("\n"));
+
+        String prompt = """
+			너는 쇼핑몰 상품 리뷰를 요약하는 시스템이다.
+			아래 리뷰 텍스트만 근거로 한국어로 요약하라. 과장/추정/허위 금지.
+
+			반드시 JSON만 출력하라(코드블록 금지, 추가 텍스트 금지).
+			형식:
+			{"summary":"...","pros":["...","...","..."],"cons":["...","...","..."],"keywords":["...","...","..."]}
+
+			규칙:
+			- pros/cons는 정확히 3개
+			- keywords는 정확히 3개(명사 위주)
+			- summary는 2~3문장
+
+			참고 지표:
+			- 평균 평점: %s
+			- 평점 분포: %s
+
+			리뷰:
+			%s
+			""".formatted(String.format("%.2f", avgRating), dist, reviewLines);
+
+        String content = chatClient.prompt()
+            .user(prompt)
+            .call()
+            .content();
+
+        Output out = parseJson(content);
+
+        return new Result(
+            out.summary(),
+            out.pros(),
+            out.cons(),
+            out.keywords(),
+            model,
+            promptVersion
+        );
+    }
+
+    private Output parseJson(String content) {
+        try {
+            String json = stripCodeFence(content);
+            return objectMapper.readValue(json, Output.class);
+        } catch (Exception e) {
+            log.warn("AI 응답 JSON 파싱 실패. raw={}", content, e);
+            throw new IllegalStateException("AI 응답 JSON 파싱 실패", e);
+        }
+    }
+
+    private String stripCodeFence(String s) {
+        if (s == null) return "";
+        String t = s.trim();
+        if (t.startsWith("```")) {
+            t = t.replaceFirst("^```[a-zA-Z]*\\s*", "");
+            t = t.replaceFirst("\\s*```$", "");
+        }
+        return t.trim();
+    }
+
+    private String trimTo(String s, int max) {
+        if (s == null) return "";
+        String t = s.replaceAll("\\s+", " ").trim();
+        return t.length() <= max ? t : t.substring(0, max) + "...";
+    }
+
+    private record Output(
+        String summary,
+        List<String> pros,
+        List<String> cons,
+        List<String> keywords
+    ) {}
+}

--- a/src/main/java/com/kt/service/ReviewSummaryGenerator.java
+++ b/src/main/java/com/kt/service/ReviewSummaryGenerator.java
@@ -1,0 +1,22 @@
+package com.kt.service;
+
+import java.util.List;
+import java.util.Map;
+
+import com.kt.domain.review.Review;
+
+/**
+ * 리뷰 목록을 입력으로 받아 요약 결과 생성(AI 구현체로 연결)
+ */
+public interface ReviewSummaryGenerator {
+    Result generate(List<Review> reviews, double avgRating, Map<Integer, Long> ratingCounts);
+
+    record Result(
+        String summary,
+        List<String> pros,
+        List<String> cons,
+        List<String> keywords,
+        String model,
+        String promptVersion
+    ) {}
+}

--- a/src/main/java/com/kt/service/ReviewSummaryService.java
+++ b/src/main/java/com/kt/service/ReviewSummaryService.java
@@ -1,0 +1,136 @@
+package com.kt.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.domain.review.Review;
+import com.kt.domain.reviewsummary.ReviewSummary;
+import com.kt.dto.reviewsummary.ReviewSummaryResponse;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.reviewsummary.ReviewSummaryRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 리뷰 요약 캐시를 조회/갱신하고, 필요 시 AI로 요약 생성
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewSummaryService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewSummaryRepository reviewSummaryRepository;
+    private final ReviewSummaryGenerator reviewSummaryGenerator;
+
+    @Value("${review-summary.max-reviews:30}")
+    private int maxReviews;
+
+    @Value("${review-summary.ttl-hours:24}")
+    private int ttlHours;
+
+    @Transactional
+    public ReviewSummaryResponse getOrGenerate(Long productId) {
+        var now = LocalDateTime.now();
+
+        var latestReviews = reviewRepository.findRecentForSummary(productId, PageRequest.of(0, 1));
+        Long latestReviewId = latestReviews.isEmpty() ? null : latestReviews.get(0).getId();
+
+        var cached = reviewSummaryRepository.findByProductId(productId).orElse(null);
+        if (cached != null && cached.isValid(now) && equalsLong(cached.getLastReviewIdUsed(), latestReviewId)) {
+            return ReviewSummaryResponse.from(cached);
+        }
+
+        var reviews = reviewRepository.findRecentForSummary(productId, PageRequest.of(0, maxReviews));
+        if (reviews.isEmpty()) {
+            var empty = ReviewSummary.of(
+                productId,
+                0,
+                null,
+                "아직 리뷰가 충분하지 않아 요약을 제공할 수 없습니다.",
+                List.of(),
+                List.of(),
+                List.of(),
+                "none",
+                "v1",
+                now,
+                now.plusHours(ttlHours)
+            );
+
+            replaceCache(cached, empty);
+            return ReviewSummaryResponse.from(empty);
+        }
+
+        var avgRating = reviews.stream().mapToInt(Review::getRating).average().orElse(0.0);
+        Map<Integer, Long> ratingCounts = reviews.stream()
+            .collect(Collectors.groupingBy(Review::getRating, Collectors.counting()));
+
+        var lastReviewIdUsed = reviews.get(0).getId();
+
+        try {
+            var ai = reviewSummaryGenerator.generate(reviews, avgRating, ratingCounts);
+
+            var entity = ReviewSummary.of(
+                productId,
+                reviews.size(),
+                lastReviewIdUsed,
+                ai.summary(),
+                ai.pros(),
+                ai.cons(),
+                ai.keywords(),
+                ai.model(),
+                ai.promptVersion(),
+                now,
+                now.plusHours(ttlHours)
+            );
+
+            replaceCache(cached, entity);
+            return ReviewSummaryResponse.from(entity);
+
+        } catch (Exception e) {
+            log.warn("리뷰 요약 생성 실패 - productId={}, reviews={}", productId, reviews.size(), e);
+            if (cached != null) {
+                return ReviewSummaryResponse.from(cached);
+            }
+
+            var failed = ReviewSummary.of(
+                productId,
+                reviews.size(),
+                lastReviewIdUsed,
+                "리뷰 요약 생성에 실패했습니다. 잠시 후 다시 시도해주세요.",
+                List.of(),
+                List.of(),
+                List.of(),
+                "none",
+                "v1",
+                now,
+                now.plusHours(1)
+            );
+
+            replaceCache(null, failed);
+            return ReviewSummaryResponse.from(failed);
+        }
+    }
+
+    private void replaceCache(ReviewSummary oldCache, ReviewSummary newCache) {
+        if (oldCache != null) {
+            reviewSummaryRepository.delete(oldCache);
+            reviewSummaryRepository.flush();
+        }
+        reviewSummaryRepository.save(newCache);
+    }
+
+    private boolean equalsLong(Long a, Long b) {
+        if (a == null && b == null) return true;
+        if (a == null || b == null) return false;
+        return a.equals(b);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,11 +6,12 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      #create = 테이블을 만들기만
-      #update = 테이블 없으면 만들고 있지만 entity랑 다르면 수정 -> 삭제는 안해줌
-      #validate = 테이블이랑 entity랑 맞는지 확인만
-      #none = 아무것도 안함
-      #create-drop = create랑 똑같은데 애플리케이션 종료시점에 테이블을 drop함 => 테스트코드에서만 쓰세요
+      # hibernate.ddl-auto: 테이블 자동 생성 옵션
+      #create:      기존 삭제 후 생성
+      #update:      엔티티 수정사항만 반영 (컬럼 추가 등, 삭제는 불가)
+      #validate:    엔티티-테이블 매핑 일치 확인 (다르면 에러)
+      #none:        자동 생성 기능 비활성화 (운영 환경 권장)
+      #create-drop: 시작 시 생성, 종료 시 테이블 삭제 (테스트용)
       ddl-auto: update
     properties:
       hibernate:
@@ -42,6 +43,20 @@ spring:
         options:
           model: gpt-4o-mini
           temperature: 0.7
+
+    retry:  # OpenAi 호출 실패 대비 재시도 설정
+      max-attempts: 4
+      backoff:
+        initial-interval: 1s
+        multiplier: 2
+        max-interval: 10s
+
+review-summary:   #리뷰 요약 기능 설정
+  max-reviews: 30 # 요약에 사용할 최근 리뷰 개수
+  ttl-hours: 24   # 요약 캐시 유효시간
+
+openai:
+  prompt-version: v1
 
 s3:
   bucket: kt-techup-shopping-prod-media

--- a/src/test/java/com/kt/service/ReviewSummaryServiceTest.java
+++ b/src/test/java/com/kt/service/ReviewSummaryServiceTest.java
@@ -1,0 +1,168 @@
+package com.kt.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.kt.domain.product.Product;
+import com.kt.domain.review.Review;
+import com.kt.domain.reviewsummary.ReviewSummary;
+import com.kt.domain.user.User;
+import com.kt.dto.reviewsummary.ReviewSummaryResponse;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.reviewsummary.ReviewSummaryRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.support.fixture.ProductFixture;
+import com.kt.support.fixture.UserFixture;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "review-summary.max-reviews=30",
+    "review-summary.ttl-hours=24",
+    "openai.prompt-version=test-v1"
+})
+class ReviewSummaryServiceTest {
+    @Autowired
+    private ReviewSummaryService reviewSummaryService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private ReviewSummaryRepository reviewSummaryRepository;
+
+    @MockBean
+    private ReviewSummaryGenerator reviewSummaryGenerator;
+
+    private User user;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(UserFixture.defaultCustomer());
+        product = productRepository.save(ProductFixture.product("원두A", 15000L, 100L, "원두 설명"));
+
+        // AI 결과는 항상 고정값 반환(외부 호출 X)
+        when(reviewSummaryGenerator.generate(any(), anyDouble(), any()))
+            .thenReturn(new ReviewSummaryGenerator.Result(
+                "테스트 요약입니다.",
+                List.of("향이 좋음", "밸런스 좋음", "데일리로 무난"),
+                List.of("개인 취향 차이", "향이 약하게 느껴질 수 있음", "진한 맛 선호자는 아쉬움"),
+                List.of("밸런스", "향", "데일리"),
+                "gpt-test",
+                "test-v1"
+            ));
+    }
+
+    @Test
+    @DisplayName("캐시가 없으면 리뷰를 기반으로 요약을 생성하고 캐시에 저장한다")
+    void 캐시없음_생성_저장() {
+        // given
+        reviewRepository.save(new Review("향이 깔끔하고 무난해요", 5, user, product, null));
+        reviewRepository.save(new Review("라떼로 마시기 좋아요", 4, user, product, null));
+
+        // when
+        ReviewSummaryResponse response = reviewSummaryService.getOrGenerate(product.getId());
+
+        // then
+        assertThat(response.summary()).isEqualTo("테스트 요약입니다.");
+        assertThat(reviewSummaryRepository.findByProductId(product.getId())).isPresent();
+
+        // generator 1회 호출
+        verify(reviewSummaryGenerator, times(1)).generate(any(), anyDouble(), any());
+    }
+
+    @Test
+    @DisplayName("캐시가 유효하고 최신 리뷰 id가 동일하면 AI를 재호출하지 않고 캐시를 반환한다")
+    void 캐시히트_재호출없음() {
+        // given: 리뷰 1개
+        Review r1 = reviewRepository.save(new Review("배송 빠르고 신선해요", 5, user, product, null));
+
+        // 캐시를 미리 만들어 둠 (lastReviewIdUsed = r1.id, expiresAt = 미래)
+        LocalDateTime now = LocalDateTime.now();
+        ReviewSummary cached = ReviewSummary.of(
+            product.getId(),
+            1,
+            r1.getId(),
+            "기존 캐시 요약",
+            List.of("장점1", "장점2", "장점3"),
+            List.of("단점1", "단점2", "단점3"),
+            List.of("키워드1", "키워드2", "키워드3"),
+            "cached-model",
+            "cached-v1",
+            now,
+            now.plusHours(24)
+        );
+        reviewSummaryRepository.save(cached);
+
+        // when
+        ReviewSummaryResponse response = reviewSummaryService.getOrGenerate(product.getId());
+
+        // then: 캐시 그대로 반환
+        assertThat(response.summary()).isEqualTo("기존 캐시 요약");
+
+        // generator 호출 없음
+        verify(reviewSummaryGenerator, never()).generate(any(), anyDouble(), any());
+    }
+
+    @Test
+    @DisplayName("새 리뷰가 추가되어 최신 리뷰 id가 변경되면 캐시를 재생성한다")
+    void 최신리뷰변경_재생성() {
+        // given: 기존 리뷰 + 기존 캐시
+        Review oldReview = reviewRepository.save(new Review("무난합니다", 4, user, product, null));
+
+        LocalDateTime now = LocalDateTime.now();
+        ReviewSummary cached = ReviewSummary.of(
+            product.getId(),
+            1,
+            oldReview.getId(),
+            "기존 캐시 요약",
+            List.of("장점1", "장점2", "장점3"),
+            List.of("단점1", "단점2", "단점3"),
+            List.of("키워드1", "키워드2", "키워드3"),
+            "cached-model",
+            "cached-v1",
+            now,
+            now.plusHours(24)
+        );
+        reviewSummaryRepository.save(cached);
+
+        // 새 리뷰 추가(최신 id 변경)
+        reviewRepository.save(new Review("향이 더 좋아요", 5, user, product, null));
+
+        // when
+        ReviewSummaryResponse response = reviewSummaryService.getOrGenerate(product.getId());
+
+        // then: mock 결과(재생성 결과) 반환
+        assertThat(response.summary()).isEqualTo("테스트 요약입니다.");
+
+        // generator 1회 호출
+        verify(reviewSummaryGenerator, times(1)).generate(any(), anyDouble(), any());
+
+        // 캐시가 갱신되었는지 확인(요약 내용 기준)
+        var saved = reviewSummaryRepository.findByProductId(product.getId()).orElseThrow();
+        assertThat(saved.getSummary()).isEqualTo("테스트 요약입니다.");
+    }
+}


### PR DESCRIPTION
### 🔧 구현 내용

* 상품 상세에서 리뷰 요약을 바로 보여주기 위해, **최근 리뷰를 모아 AI가 요약을 생성**하고 결과를 조회하는 API를 추가했습니다.
* 동작 흐름

  * (1) 상품의 **최근 리뷰 N개** 조회(블라인드 리뷰/빈 내용 제외)
  * (2) 리뷰로부터 **평균 별점/별점 분포** 계산
  * (3) AI(OpenAI)에 요약을 요청해 **요약문 + 장점 3개 + 단점 3개 + 키워드 3개** 생성
  * (4) 생성 결과를 `review_summaries` 테이블에 저장해, **같은 상품 요청이 반복되면 캐시 재사용**
  * (5) 새 리뷰가 추가되었거나 캐시가 만료되면 **요약을 다시 생성**
* 공개 성격의 정보이므로, **리뷰 요약 조회 API는 비로그인 접근이 가능**하도록 Security 설정을 추가

### 📌 관련 Jira Issue

* KAN-129

### 🧪 테스트 방법

1. ReviewSummaryServiceTest 통과
2. Swagger API 호출

* 비로그인 호출 가능 확인

  * `GET /api/reviews/summary?productId={productId}`
  * 체크: 401/403 없이 200 응답
* 리뷰 없음 케이스

  * productId에 리뷰가 없을 때 “리뷰 부족” 메시지 반환 및 캐시 저장 여부 확인
* 리뷰 있음/AI 생성 케이스

  * 더미 리뷰 삽입 후 호출
  * 체크: `summary`(2~3문장), `pros/cons/keywords` 각 3개 반환, `review_summaries` 테이블에 저장
* 캐시 재사용 확인

  * 동일 productId 재호출
  * 체크: `generatedAt` 유지(재생성 안 됨)
* 재생성 확인

  * 해당 상품에 리뷰 추가 후 재호출
  * 체크: `lastReviewIdUsed` 변경 및 `generatedAt` 갱신

### ❗ 기타 참고 사항

* `order_product_id` 유니크 제약으로 더미 리뷰 삽입 시 `order_product_id`는 NULL로 생성(요약 기능에는 영향 없음)
* AI 응답은 JSON만 허용하며, 코드블록 포함 시 제거 후 파싱 처리
* 캐시 충돌 방지를 위해 갱신 시 기존 캐시 삭제 후 저장(유니크 `product_id` 기준)
