### PR TITLE
chore(localstack): Localstack 데이터 영속성 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ application-local.yml
 
 # Qdrant
 /qdrant/
+
+# Localstack
+
+/localstack/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,10 @@ services:
     ports:
       - "4566:4566"
     volumes:
+      - "./localstack:/var/lib/localstack"
       - "./init-s3.sh:/etc/localstack/init/ready.d/init-s3.sh"
+    environment:
+      - PERSISTENCE=1
     entrypoint: >
       /bin/sh -c "chmod +x /etc/localstack/init/ready.d/init-s3.sh && /usr/local/bin/docker-entrypoint.sh"
 


### PR DESCRIPTION

### 🔧 구현 내용

- docker-compose.yml에 데이터 영속성을 위한 볼륨 및 환경 변수 추가
- .gitignore에 로컬 데이터 디렉토리(/localstack/) 추가

[변경 전] 서버 재시작시 Localstack bucket이 초기화 돼서 재생성 필요
[변경 후] local 및 docker 내부에 Localstack 데이터를 저장해 데이터 영속성 유지

### 📌 관련 Jira Issue


### 🧪 테스트 방법

서버 재시작 후 bucket 및 데이터 유지 확인

### ❗ 기타 참고 사항